### PR TITLE
Fix resource names and golint errors

### DIFF
--- a/cas/core_acceptance_test.go
+++ b/cas/core_acceptance_test.go
@@ -24,7 +24,7 @@ func TestAccTangoWordpressInfrastructure_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckTangoWordpressInfrastructureDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTangoWordpressInfrastructureConfig_basic(nRint, mRInt, wRint),
+				Config: testAccCheckTangoWordpressInfrastructureConfig(nRint, mRInt, wRint),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTangoWordpressInfrastructureResourceExists("tango_network.network"),
 					testAccCheckTangoWordpressInfrastructureResourceExists("tango_machine.mysql"),
@@ -105,7 +105,7 @@ func testAccCheckTangoWordpressInfrastructureDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckTangoWordpressInfrastructureConfig_basic(nRInt, mRInt, wRInt int) string {
+func testAccCheckTangoWordpressInfrastructureConfig(nRInt, mRInt, wRInt int) string {
 	return fmt.Sprintf(`
 resource "tango_network" "network" {
 	name = "terraform_tango_network-%d"

--- a/cas/provider.go
+++ b/cas/provider.go
@@ -46,10 +46,10 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"tango_machine":       resourceMachine(),
-			"tango_network":       resourceNetwork(),
-			"tango_block_device":  resourceBlockDevice(),
-			"tango_load_balancer": resourceLoadBalancer(),
+			"cas_machine":       resourceMachine(),
+			"cas_network":       resourceNetwork(),
+			"cas_block_device":  resourceBlockDevice(),
+			"cas_load_balancer": resourceLoadBalancer(),
 		},
 
 		ConfigureFunc: configureProvider,

--- a/cas/resource_block_device_test.go
+++ b/cas/resource_block_device_test.go
@@ -22,7 +22,7 @@ func TestAccTangoBlockDevice_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckTangoBlockDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTangoBlockDeviceConfig_basic(rInt),
+				Config: testAccCheckTangoBlockDeviceConfig(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTangoBlockDeviceExists("tango_block_device.my_block_device"),
 					resource.TestMatchResourceAttr(
@@ -76,7 +76,7 @@ func testAccCheckTangoBlockDeviceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckTangoBlockDeviceConfig_basic(rInt int) string {
+func testAccCheckTangoBlockDeviceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "tango_block_device" "my_block_device" {
   name = "terraform_tango_block_device-%d"

--- a/cas/resource_load_balancer_test.go
+++ b/cas/resource_load_balancer_test.go
@@ -22,7 +22,7 @@ func TestAccTangoLoadBalancer_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckTangoLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTangoLoadBalancerConfig_basic(rInt),
+				Config: testAccCheckTangoLoadBalancerConfig(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTangoLoadBalancerExists("tango_load_balancer.my_load_balancer"),
 					resource.TestMatchResourceAttr(
@@ -96,7 +96,7 @@ func testAccCheckTangoLoadBalancerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckTangoLoadBalancerConfig_basic(rInt int) string {
+func testAccCheckTangoLoadBalancerConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "tango_network" "my_network" {
 	name = "terraform_tango_network"

--- a/cas/resource_machine.go
+++ b/cas/resource_machine.go
@@ -3,7 +3,6 @@ package cas
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 
 	"github.com/vmware/terraform-provider-cas/sdk"
@@ -265,24 +264,26 @@ func resourceMachineUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceMachineDelete(d *schema.ResourceData, m interface{}) error {
 	client := m.(*tango.Client)
 
-	resourceObject, err := client.ReadResource(getSelfLink(d.Get("links").([]interface{})) + "/disks")
-	if err != nil {
-		return err
-	}
+	// TODO: Confirm that deleting the machine also deletes all the attached disks automatically.
+	// Commented the code as the machine deletion is failing while trying to detach the boot-disk.
+	//resourceObject, err := client.ReadResource(getSelfLink(d.Get("links").([]interface{})) + "/disks")
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//machineAttachedDisksObject := resourceObject.(*tango.MachineAttachedDisks)
+	//
+	//peripheralDevicesRegex := regexp.MustCompile("^(CD/DVD|Floppy) drive")
+	//for _, blockDevice := range machineAttachedDisksObject.Content {
+	//	if blockDevice.Name != "boot-disk" && !peripheralDevicesRegex.MatchString(blockDevice.Name) {
+	//		err := client.DeleteResource(blockDevice.Links["self"].Href) // detach disks first
+	//		if err != nil {
+	//			return err
+	//		}
+	//	}
+	//}
 
-	machineAttachedDisksObject := resourceObject.(*tango.MachineAttachedDisks)
-
-	peripheralDevicesRegex := regexp.MustCompile("^(CD/DVD|Floppy) drive")
-	for _, blockDevice := range machineAttachedDisksObject.Content {
-		if blockDevice.Name != "boot-disk" && !peripheralDevicesRegex.MatchString(blockDevice.Name) {
-			err := client.DeleteResource(blockDevice.Links["self"].Href) // detach disks first
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	err = client.DeleteResource(getSelfLink(d.Get("links").([]interface{})))
+	err := client.DeleteResource(getSelfLink(d.Get("links").([]interface{})))
 
 	if err != nil && strings.Contains(err.Error(), "404") { // already deleted
 		return nil

--- a/cas/resource_machine_test.go
+++ b/cas/resource_machine_test.go
@@ -22,21 +22,21 @@ func TestAccTangoMachine_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckTangoMachineDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTangoMachineConfig_basic(rInt),
+				Config: testAccCheckTangoMachineConfig(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTangoMachineExists("tango_machine.my_machine"),
+					testAccCheckTangoMachineExists("cas_machine.my_machine"),
 					resource.TestMatchResourceAttr(
-						"tango_machine.my_machine", "name", regexp.MustCompile("^terraform_tango_machine-"+strconv.Itoa(rInt))),
+						"cas_machine.my_machine", "name", regexp.MustCompile("^terraform_cas_machine-"+strconv.Itoa(rInt))),
 					resource.TestCheckResourceAttr(
-						"tango_machine.my_machine", "image", "ubuntu"),
+						"cas_machine.my_machine", "image", "ubuntu"),
 					resource.TestCheckResourceAttr(
-						"tango_machine.my_machine", "flavor", "small"),
+						"cas_machine.my_machine", "flavor", "small"),
 					resource.TestCheckResourceAttr(
-						"tango_machine.my_machine", "tags.#", "1"),
+						"cas_machine.my_machine", "tags.#", "1"),
 					resource.TestCheckResourceAttr(
-						"tango_machine.my_machine", "tags.0.key", "stoyan"),
+						"cas_machine.my_machine", "tags.0.key", "stoyan"),
 					resource.TestCheckResourceAttr(
-						"tango_machine.my_machine", "tags.0.value", "genchev"),
+						"cas_machine.my_machine", "tags.0.value", "genchev"),
 				),
 			},
 		},
@@ -47,11 +47,11 @@ func testAccCheckTangoMachineExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Machine ID is set")
+			return fmt.Errorf("no machine ID is set")
 		}
 
 		return nil
@@ -62,7 +62,7 @@ func testAccCheckTangoMachineDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*tango.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "tango_machine" {
+		if rs.Type != "cas_machine" {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func testAccCheckTangoMachineDestroy(s *terraform.State) error {
 
 		if err != nil && !strings.Contains(err.Error(), "404") {
 			return fmt.Errorf(
-				"Error waiting for machine (%s) to be destroyed: %s",
+				"error waiting for machine (%s) to be destroyed: %s",
 				rs.Primary.ID, err)
 		}
 	}
@@ -78,10 +78,10 @@ func testAccCheckTangoMachineDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckTangoMachineConfig_basic(rInt int) string {
+func testAccCheckTangoMachineConfig(rInt int) string {
 	return fmt.Sprintf(`
-resource "tango_machine" "my_machine" {
-  name = "terraform_tango_machine-%d"
+resource "cas_machine" "my_machine" {
+  name = "terraform_cas_machine-%d"
   image = "ubuntu"
   flavor = "small"
 

--- a/cas/resource_network_test.go
+++ b/cas/resource_network_test.go
@@ -22,7 +22,7 @@ func TestAccTangoNetwork_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckTangoNetworkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckTangoNetworkConfig_basic(rInt),
+				Config: testAccCheckTangoNetworkConfig(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTangoNetworkExists("tango_network.my_network"),
 					resource.TestMatchResourceAttr(
@@ -84,7 +84,7 @@ func testAccCheckTangoNetworkDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckTangoNetworkConfig_basic(rInt int) string {
+func testAccCheckTangoNetworkConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "tango_network" "my_network" {
   name = "terraform_tango_network-%d"

--- a/examples/machine-network/main.tf
+++ b/examples/machine-network/main.tf
@@ -1,12 +1,12 @@
-provider "tango" {
+provider "cas" {
     url = "${var.url}"
     access_token = "${var.access_token}"
     project_id = "${var.project_id}"
     deployment_id = "${var.deployment_id}"
 }
 
-resource "tango_machine" "my_machine_mysql" {
-    name = "terraform_tango_mysql"
+resource "cas_machine" "my_machine_mysql" {
+    name = "terraform_cas_mysql"
     image = "ubuntu"
     flavor = "small"
 

--- a/examples/wordpress/main.tf
+++ b/examples/wordpress/main.tf
@@ -1,12 +1,12 @@
-provider "tango" {
+provider "cas" {
     url = "${var.url}"
     access_token = "${var.access_token}"
     project_id = "${var.project_id}"
     deployment_id = "${var.deployment_id}"
 }
 
-resource "tango_machine" "my_machine_mysql" {
-    name = "terraform_tango_mysql"
+resource "cas_machine" "my_machine_mysql" {
+    name = "terraform_cas_mysql"
     image = "ubuntu"
     flavor = "small"
 
@@ -28,8 +28,8 @@ EOF
     }
 }
 
-resource "tango_machine" "my_machine_wordpress" {
-    name = "terraform_tango_wordpress"
+resource "cas_machine" "my_machine_wordpress" {
+    name = "terraform_cas_wordpress"
     image = "ubuntu"
     flavor = "small"
 
@@ -49,10 +49,10 @@ packages:
 
 runcmd:
 - mkdir -p /var/www/html/mywordpresssite && cd /var/www/html && wget https://wordpress.org/latest.tar.gz && tar -xzf /var/www/html/latest.tar.gz -C /var/www/html/mywordpresssite --strip-components 1
-- i=0; while [ $i -le 10 ]; do mysql --connect-timeout=3 -h ${tango_machine.my_machine_mysql.address} -u root -pmysqlpassword -e "SHOW STATUS;" && break || sleep 15; i=$$((i+1)); done
-- mysql -u root -pmysqlpassword -h ${tango_machine.my_machine_mysql.address} -e "create database wordpress_blog;"
+- i=0; while [ $i -le 10 ]; do mysql --connect-timeout=3 -h ${cas_machine.my_machine_mysql.address} -u root -pmysqlpassword -e "SHOW STATUS;" && break || sleep 15; i=$$((i+1)); done
+- mysql -u root -pmysqlpassword -h ${cas_machine.my_machine_mysql.address} -e "create database wordpress_blog;"
 - mv /var/www/html/mywordpresssite/wp-config-sample.php /var/www/html/mywordpresssite/wp-config.php
-- sed -i -e s/"define('DB_NAME', 'database_name_here');"/"define('DB_NAME', 'wordpress_blog');"/ /var/www/html/mywordpresssite/wp-config.php && sed -i -e s/"define('DB_USER', 'username_here');"/"define('DB_USER', 'root');"/ /var/www/html/mywordpresssite/wp-config.php && sed -i -e s/"define('DB_PASSWORD', 'password_here');"/"define('DB_PASSWORD', 'mysqlpassword');"/ /var/www/html/mywordpresssite/wp-config.php && sed -i -e s/"define('DB_HOST', 'localhost');"/"define('DB_HOST', '${tango_machine.my_machine_mysql.address}');"/ /var/www/html/mywordpresssite/wp-config.php
+- sed -i -e s/"define('DB_NAME', 'database_name_here');"/"define('DB_NAME', 'wordpress_blog');"/ /var/www/html/mywordpresssite/wp-config.php && sed -i -e s/"define('DB_USER', 'username_here');"/"define('DB_USER', 'root');"/ /var/www/html/mywordpresssite/wp-config.php && sed -i -e s/"define('DB_PASSWORD', 'password_here');"/"define('DB_PASSWORD', 'mysqlpassword');"/ /var/www/html/mywordpresssite/wp-config.php && sed -i -e s/"define('DB_HOST', 'localhost');"/"define('DB_HOST', '${cas_machine.my_machine_mysql.address}');"/ /var/www/html/mywordpresssite/wp-config.php
 - service apache2 reload
 EOF
     }

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -18,6 +18,7 @@ const (
 	loginEndpoint         = "/iaas/login"
 )
 
+// Client used to store the Cloud Automation Services (cas) client and the provider configuration.
 type Client struct {
 	client       *http.Client
 	base         string
@@ -26,14 +27,17 @@ type Client struct {
 	deploymentID string
 }
 
+// GetProjectID returns the "project_id" from "cas" provider configuration
 func (c *Client) GetProjectID() string {
 	return c.projectID
 }
 
+// GetDeploymentID returns the "deployment_id" from "cas" provider configuration
 func (c *Client) GetDeploymentID() string {
 	return c.deploymentID
 }
 
+// NewClientFromRefreshToken configures and returns a CAS "Client" struct using "refresh_token" from provider config
 func NewClientFromRefreshToken(url, refreshToken, projectID, deploymentID string) (interface{}, error) {
 	var netClient = &http.Client{
 		Timeout: time.Second * 20,
@@ -79,6 +83,7 @@ func NewClientFromRefreshToken(url, refreshToken, projectID, deploymentID string
 	return &Client{netClient, url, loginResponse.Token, projectID, deploymentID}, nil
 }
 
+// NewClientFromAccessToken configures and returns a CAS "Client" struct using "access_token" from provider config
 func NewClientFromAccessToken(url, accessToken, projectID, deploymentID string) (interface{}, error) {
 	var netClient = &http.Client{
 		Timeout: time.Second * 20,
@@ -109,6 +114,7 @@ func NewClientFromAccessToken(url, accessToken, projectID, deploymentID string) 
 	return &Client{netClient, url, accessToken, projectID, deploymentID}, nil
 }
 
+// CreateResource creates a cas resource with the given resource specification.
 func (c *Client) CreateResource(resourceSpecification ResourceSpecification) (interface{}, error) {
 	resourceSpecificationBytes, err := json.Marshal(resourceSpecification)
 	if err != nil {
@@ -156,6 +162,7 @@ func (c *Client) CreateResource(resourceSpecification ResourceSpecification) (in
 	return c.ReadResource(requestTrackerResponse.Resources[0])
 }
 
+// ReadResource returns the resource description for the given resource endpoint
 func (c *Client) ReadResource(resourceEndpoint string) (interface{}, error) {
 	request, err := http.NewRequest(http.MethodGet, c.base+resourceEndpoint, nil)
 	if err != nil {
@@ -189,6 +196,7 @@ func (c *Client) ReadResource(resourceEndpoint string) (interface{}, error) {
 	return resourceObject, nil
 }
 
+// DeleteResource deletes the given resource
 func (c *Client) DeleteResource(resourceEndpoint string) error {
 	request, err := http.NewRequest(http.MethodDelete, c.base+resourceEndpoint, nil)
 	if err != nil {

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -13,23 +13,26 @@ const (
 )
 
 var (
-	machineEndpointDisksR = regexp.MustCompile("^/iaas/machines/[a-zA-Z0-9]+/disks")
-	machineEndpointR      = regexp.MustCompile("^/iaas/machines")
-	networkEndpointR      = regexp.MustCompile("^/iaas/networks")
-	blockDeviceEndpointR  = regexp.MustCompile("^/iaas/block-devices")
-	loadBalancerEndpointR = regexp.MustCompile("^/iaas/load-balancers")
+	machineEndpointDisksR = regexp.MustCompile("^/iaas/api/machines/[a-zA-Z0-9]+/disks")
+	machineEndpointR      = regexp.MustCompile("^/iaas/api/machines")
+	networkEndpointR      = regexp.MustCompile("^/iaas/api/networks")
+	blockDeviceEndpointR  = regexp.MustCompile("^/iaas/api/block-devices")
+	loadBalancerEndpointR = regexp.MustCompile("^/iaas/api/load-balancers")
 )
 
+// Tag consists of key, value pair.
 type Tag struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
 
+// Constraint represents the condition that one resource may have on other resources.
 type Constraint struct {
 	Mandatory  bool   `json:"mandatory"`
 	Expression string `json:"expression"`
 }
 
+// Nic represents the machine network interface configuration.
 type Nic struct {
 	Name             string            `json:"name,omitempty"`
 	Description      string            `json:"description,omitempty"`
@@ -40,12 +43,15 @@ type Nic struct {
 	CustomProperties map[string]string `json:"customProperties,omitempty"`
 }
 
+// Disk represents the disk configuration.
 type Disk struct {
 	Name          string `json:"name,omitempty"`
 	Description   string `json:"description,omitempty"`
 	BlockDeviceID string `json:"blockDeviceId"`
 }
 
+// Route represents the configuration for routing incoming requests to the back-end instances.
+// A load balancer may support multiple such configurations.
 type Route struct {
 	Protocol       string                    `json:"protocol"`
 	Port           string                    `json:"port"`
@@ -54,6 +60,8 @@ type Route struct {
 	HCC            *HealthCheckConfiguration `json:"healthCheckConfiguration,omitempty"`
 }
 
+// HealthCheckConfiguration represents a load balancer configuration for checking the health of
+// the load-balanced back-end instances.
 type HealthCheckConfiguration struct {
 	Protocol          string `json:"protocol"`
 	Port              string `json:"port"`
@@ -64,15 +72,18 @@ type HealthCheckConfiguration struct {
 	HealthThreshold   int    `json:"healthyThreshold,omitempty"`
 }
 
+// LoginRequest consits of the refresh token used to login to CAS.
 type LoginRequest struct {
 	RefreshToken string `json:"refreshToken"`
 }
 
+// LoginResponse consists of a token and its type after the request is successfully authenticated.
 type LoginResponse struct {
 	TokenType string `json:"tokenType"`
 	Token     string `json:"token"`
 }
 
+// LoadBalancerSpecification represents the cas_load_balancer resource configuration.
 type LoadBalancerSpecification struct {
 	Name             string            `json:"name,omitempty"`
 	Description      string            `json:"description,omitempty"`
@@ -86,6 +97,7 @@ type LoadBalancerSpecification struct {
 	Routes           []Route           `json:"routes"`
 }
 
+// MachineSpecification represents the cas_machine resource configuration.
 type MachineSpecification struct {
 	Name             string            `json:"name,omitempty"`
 	Description      string            `json:"description,omitempty"`
@@ -102,6 +114,7 @@ type MachineSpecification struct {
 	BootConfig       map[string]string `json:"bootConfig,omitempty"`
 }
 
+// NetworkSpecification represents the cas_network resource configuration.
 type NetworkSpecification struct {
 	Name             string            `json:"name,omitempty"`
 	Description      string            `json:"description,omitempty"`
@@ -113,6 +126,7 @@ type NetworkSpecification struct {
 	OutboundAccess   bool              `json:"outboundAccess,omitempty"`
 }
 
+// BlockDeviceSpecification represents the cas_block_device resource configuration.
 type BlockDeviceSpecification struct {
 	Name              string            `json:"name,omitempty"`
 	Description       string            `json:"description,omitempty"`
@@ -127,6 +141,7 @@ type BlockDeviceSpecification struct {
 	Tags              []Tag             `json:"tags,omitempty"`
 }
 
+// CreateResourceEndpointResponse consists of id, name, status, selfLink and the progress.
 type CreateResourceEndpointResponse struct {
 	Progress int8   `json:"progress"`
 	Status   string `json:"status"`
@@ -135,6 +150,7 @@ type CreateResourceEndpointResponse struct {
 	SelfLink string `json:"selfLink"`
 }
 
+// RequestTrackerResponse is the response received for the on-going tracker requests.
 type RequestTrackerResponse struct {
 	Progress  int8     `json:"progress"`
 	Message   string   `json:"message"`
@@ -146,11 +162,13 @@ type RequestTrackerResponse struct {
 	SelfLink  string   `json:"selfLink"`
 }
 
+// HypertextReference is used to represent the link(s) that one resource might have to other resources.
 type HypertextReference struct {
 	Href  string   `json:"href,omitempty"`
 	Hrefs []string `json:"hrefs,omitempty"`
 }
 
+// Machine is used to represent a CAS provisioned machine state.
 type Machine struct {
 	PowerState       string                        `json:"powerState"`
 	Address          string                        `json:"address"`
@@ -171,6 +189,7 @@ type Machine struct {
 	Tags             []Tag                         `json:"tags"`
 }
 
+// Network is used to represent a CAS provisioned network resource state.
 type Network struct {
 	CIDR             string                        `json:"cidr"`
 	CustomProperties map[string]string             `json:"customProperties"`
@@ -188,6 +207,7 @@ type Network struct {
 	Tags             []Tag                         `json:"tags"`
 }
 
+// BlockDevice is used to represent a CAS provisioned block device resource state.
 type BlockDevice struct {
 	CapacityInGB     int                           `json:"capacityInGB"`
 	Status           string                        `json:"status"`
@@ -208,6 +228,7 @@ type BlockDevice struct {
 	Tags             []Tag                         `json:"tags"`
 }
 
+// LoadBalancer is used to represent a CAS provisioned load balancer resource state.
 type LoadBalancer struct {
 	ID               string                        `json:"id"`
 	SelfLink         string                        `json:"selfLink"`
@@ -228,11 +249,14 @@ type LoadBalancer struct {
 	Address          string                        `json:"address"`
 }
 
+// MachineAttachedDisks represent the disks attached to a machine resource.
 type MachineAttachedDisks struct {
 	Content       []BlockDevice `json:"content"`
 	TotalElements int           `json:"totalElements"`
 }
 
+// NewResourceObject returns the new resource object for a given resource endpoint.
+// Works only for supported resource endpoints.
 func NewResourceObject(endpoint string) (interface{}, error) {
 	switch {
 	case machineEndpointDisksR.MatchString(endpoint):
@@ -250,22 +274,27 @@ func NewResourceObject(endpoint string) (interface{}, error) {
 	}
 }
 
+// ResourceSpecification tracks the endpoint for CAS resources.
 type ResourceSpecification interface {
 	GetEndpoint() string
 }
 
+// GetEndpoint returns the machine endpoint.
 func (machineSpecification MachineSpecification) GetEndpoint() string {
 	return machineEndpoint
 }
 
+// GetEndpoint returns network endpoint.
 func (networkSpecification NetworkSpecification) GetEndpoint() string {
 	return networkEndpoint
 }
 
+// GetEndpoint returns the block device endpoint.
 func (blockDeviceSpecification BlockDeviceSpecification) GetEndpoint() string {
 	return blockDeviceEndpoint
 }
 
+// GetEndpoint returns the load balancer endpoint.
 func (loadBalancerSpecification LoadBalancerSpecification) GetEndpoint() string {
 	return loadBalancerEndpoint
 }


### PR DESCRIPTION
This commit fixes the resource names to use "cas_" prefix and also
fixes the golint errors.

This commit removes the detach/delete disks step before destroying
the machine resources.