### PR TITLE
Allow case-insensitive bearer for auth type matching

### DIFF
--- a/cas/client.go
+++ b/cas/client.go
@@ -53,7 +53,7 @@ func getToken(url, refreshToken string) (string, error) {
 		},
 	)
 	authTokenResponse, err := apiclient.Login.RetrieveAuthToken(params)
-	if err != nil || *authTokenResponse.Payload.TokenType != "bearer" {
+	if err != nil || !strings.EqualFold(*authTokenResponse.Payload.TokenType, "bearer") {
 		return "", err
 	}
 


### PR DESCRIPTION
Changes rolled out in staging broke the auth type matching. This will now match case-insensitive but the token sent will always be "Bearer". Fixes #33 