### PR TITLE
Add support for customizable timeouts for long running operations

### DIFF
--- a/vra/resource_block_device.go
+++ b/vra/resource_block_device.go
@@ -99,6 +99,12 @@ func resourceBlockDevice() *schema.Resource {
 				Computed: true,
 			},
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 
@@ -149,7 +155,7 @@ func resourceBlockDeviceCreate(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    blockDeviceStateRefreshFunc(*apiClient, *createBlockDeviceCreated.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 	}
 
@@ -247,7 +253,7 @@ func resourceBlockDeviceDelete(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    blockDeviceStateRefreshFunc(*apiClient, *deleteBlockDevice.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 	}
 

--- a/vra/resource_load_balancer.go
+++ b/vra/resource_load_balancer.go
@@ -95,6 +95,12 @@ func resourceLoadBalancer() *schema.Resource {
 				Computed: true,
 			},
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 
@@ -146,7 +152,7 @@ func resourceLoadBalancerCreate(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    loadBalancerStateRefreshFunc(*apiClient, *createLoadBalancerCreated.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 	}
 
@@ -252,7 +258,7 @@ func resourceLoadBalancerDelete(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    loadBalancerStateRefreshFunc(*apiClient, *deleteLoadBalancer.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 	}
 

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -131,6 +131,12 @@ func resourceMachine() *schema.Resource {
 			},
 			"links": linksSchema(),
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 
@@ -200,7 +206,7 @@ func resourceMachineCreate(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    machineStateRefreshFunc(*apiClient, *createMachineCreated.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 	}
 
@@ -315,7 +321,7 @@ func resourceMachineUpdate(d *schema.ResourceData, m interface{}) error {
 			Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 			Refresh:    machineStateRefreshFunc(*apiClient, *resizeMachine.Payload.ID),
 			Target:     []string{models.RequestTrackerStatusFINISHED},
-			Timeout:    5 * time.Minute,
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 5 * time.Second,
 		}
 
@@ -348,7 +354,7 @@ func resourceMachineDelete(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    machineStateRefreshFunc(*apiClient, *deleteMachine.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 	}
 

--- a/vra/resource_network.go
+++ b/vra/resource_network.go
@@ -78,6 +78,12 @@ func resourceNetwork() *schema.Resource {
 				Computed: true,
 			},
 		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 
@@ -116,7 +122,7 @@ func resourceNetworkCreate(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    networkStateRefreshFunc(*apiClient, *createNetworkCreated.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 5 * time.Second,
 	}
 	resourceIds, err := stateChangeFunc.WaitForState()
@@ -215,7 +221,7 @@ func resourceNetworkDelete(d *schema.ResourceData, m interface{}) error {
 		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
 		Refresh:    networkStateRefreshFunc(*apiClient, *deleteNetworkAccepted.Payload.ID),
 		Target:     []string{models.RequestTrackerStatusFINISHED},
-		Timeout:    5 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 5 * time.Second,
 	}
 


### PR DESCRIPTION
Resources that take longer to create and destroy can now use the timeouts block
with custom timeouts for create, delete and update where applicable.
Supported resources are: vra_machine, vra_network, vra_block_device, vra_load_balancer.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>