### PR TITLE
Change data collector id to optional in support of vRA 8.0

### DIFF
--- a/examples/cloud_account_vmc/main.tf
+++ b/examples/cloud_account_vmc/main.tf
@@ -1,17 +1,20 @@
 provider "vra" {
   url           = var.url
   refresh_token = var.refresh_token
+  insecure      = var.insecure // false for vRA Cloud and true for vRA 8.0
 }
 
+// Required for vRA Cloud, Optional for vRA 8.0
 data "vra_data_collector" "this" {
-  name = var.data_collector_name
+  count = var.data_collector_name != "" ? 1 : 0
+  name  = var.data_collector_name
 }
 
 data "vra_region_enumeration" "this" {
   hostname = var.vcenter_hostname
   password = var.vcenter_password
   username = var.vcenter_username
-  dcid     = data.vra_data_collector.this.id
+  dcid     = var.data_collector_name != "" ? data.vra_data_collector.this[0].id : "" // Required for vRA Cloud, Optional for vRA 8.0
 }
 
 resource "vra_cloud_account_vmc" "this" {
@@ -25,7 +28,7 @@ resource "vra_cloud_account_vmc" "this" {
   vcenter_password = var.vcenter_password
   vcenter_username = var.vcenter_username
   nsx_hostname     = var.nsx_hostname
-  dc_id            = data.vra_data_collector.this.id
+  dc_id            = var.data_collector_name != "" ? data.vra_data_collector.this[0].id : "" // Required for vRA Cloud, Optional for vRA 8.0
 
   regions                 = data.vra_region_enumeration.this.regions
   accept_self_signed_cert = true

--- a/examples/cloud_account_vmc/terraform.tfvars.sample
+++ b/examples/cloud_account_vmc/terraform.tfvars.sample
@@ -1,5 +1,6 @@
 refresh_token = ""
 url = ""
+insecure =
 api_token = ""
 data_collector_name = ""
 nsx_hostname = ""

--- a/examples/cloud_account_vmc/variables.tf
+++ b/examples/cloud_account_vmc/variables.tf
@@ -4,6 +4,9 @@ variable "url" {
 variable "refresh_token" {
 }
 
+variable "insecure" {
+}
+
 variable "api_token" {
 }
 

--- a/examples/cloud_account_vsphere/main.tf
+++ b/examples/cloud_account_vsphere/main.tf
@@ -1,17 +1,20 @@
 provider "vra" {
   url           = var.url
   refresh_token = var.refresh_token
+  insecure      = var.insecure // false for vRA Cloud and true for vRA 8.0
 }
 
+// Required for vRA Cloud, Optional for vRA 8.0
 data "vra_data_collector" "dc" {
-  name = var.datacollector
+  count = var.datacollector != "" ? 1 : 0
+  name  = var.datacollector
 }
 
 data "vra_region_enumeration" "dc_regions" {
   username = var.username
   password = var.password
   hostname = var.hostname
-  dcid     = data.vra_data_collector.dc.id
+  dcid     = var.datacollector != "" ? data.vra_data_collector.dc[0].id : "" // Required for vRA Cloud, Optional for vRA 8.0
 }
 
 resource "vra_cloud_account_vsphere" "this" {
@@ -20,7 +23,7 @@ resource "vra_cloud_account_vsphere" "this" {
   username    = var.username
   password    = var.password
   hostname    = var.hostname
-  dcid        = data.vra_data_collector.dc.id
+  dcid        = var.datacollector != "" ? data.vra_data_collector.dc[0].id : "" // Required for vRA Cloud, Optional for vRA 8.0
 
   regions                 = data.vra_region_enumeration.dc_regions.regions
   accept_self_signed_cert = true

--- a/examples/cloud_account_vsphere/terraform.tfvars.sample
+++ b/examples/cloud_account_vsphere/terraform.tfvars.sample
@@ -1,5 +1,6 @@
 refresh_token = ""
 url = ""
+insecure =
 username = ""
 password = ""
 hostname = ""

--- a/examples/cloud_account_vsphere/variables.tf
+++ b/examples/cloud_account_vsphere/variables.tf
@@ -4,6 +4,10 @@ variable "refresh_token" {
 variable "url" {
 }
 
+variable "insecure" {
+
+}
+
 variable "username" {
 }
 

--- a/vra/data_source_data_collector.go
+++ b/vra/data_source_data_collector.go
@@ -24,7 +24,6 @@ func dataSourceDataCollector() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/vra/data_source_region_enumeration.go
+++ b/vra/data_source_region_enumeration.go
@@ -15,7 +15,7 @@ func dataSourceRegionEnumeration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"dcid": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"hostname": &schema.Schema{
 				Type:     schema.TypeString,

--- a/vra/resource_cloud_account_vmc.go
+++ b/vra/resource_cloud_account_vmc.go
@@ -29,7 +29,7 @@ func resourceCloudAccountVMC() *schema.Resource {
 			},
 			"dc_id": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,

--- a/vra/resource_cloud_account_vsphere.go
+++ b/vra/resource_cloud_account_vsphere.go
@@ -24,7 +24,7 @@ func resourceCloudAccountVsphere() *schema.Resource {
 			},
 			"dcid": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"description": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
For vRA 8.0, there is no data collector needed for vsphere and vmc resources. Hence, dcid is made optional.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>