### PR TITLE
fix for vra_region_enumerations data source 

### DIFF
--- a/vra/data_source_region_enumeration.go
+++ b/vra/data_source_region_enumeration.go
@@ -54,7 +54,12 @@ func dataSourceRegionEnumerationRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("regions", getResp.Payload.ExternalRegionIds)
-	d.SetId(d.Get("dcid").(string))
+	// In case where enumerating using vRA9 on-prem the dcid is empty..so use hostname of vcenter to set ID
+	if d.Get("dcid").(string) != "" {
+		d.SetId(d.Get("dcid").(string))
+	} else {
+		d.SetId(d.Get("hostname").(string))
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fix for #139 
In the case of vRA8 on-prem the data collector value in the vra_region_enumeration block will be empty (""). The value for the data collector id (dcid)  was being used to set the ID on the resource (https://github.com/vmware/terraform-provider-vra/blob/06e538fcc91714b3cd7b98ee238a754041109e5a/vra/data_source_region_enumeration.go#L57) . Because in on-prem case this was an empty string it wasn't getting "created" by Terraform. This change uses the vCenter hostname to set the ID in the case where the dcid is empty. 



