### PR TITLE
Create transport with the requested URL path

### DIFF
--- a/vra/client.go
+++ b/vra/client.go
@@ -47,7 +47,7 @@ func getToken(url, refreshToken string, insecure bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	transport := httptransport.New(parsedURL.Host, "", nil)
+	transport := httptransport.New(parsedURL.Host, parsedURL.Path, nil)
 	newTransport, err := httptransport.TLSTransport(httptransport.TLSClientOptions{
 		InsecureSkipVerify: insecure,
 	})
@@ -106,7 +106,7 @@ func getAPIClient(url string, token string, insecure bool) (*client.MulticloudIa
 	if err != nil {
 		return nil, err
 	}
-	transport := httptransport.New(parsedURL.Host, "", nil)
+	transport := httptransport.New(parsedURL.Host, parsedURL.Path, nil)
 	transport.DefaultAuthentication = httptransport.APIKeyAuth("Authorization", "header", "Bearer "+token)
 	newTransport, err := httptransport.TLSTransport(httptransport.TLSClientOptions{
 		InsecureSkipVerify: insecure,

--- a/vra/client_test.go
+++ b/vra/client_test.go
@@ -1,0 +1,31 @@
+package vra
+
+import (
+	"testing"
+
+	"github.com/go-openapi/runtime/client"
+)
+
+func TestClient(t *testing.T) {
+	var tests = []struct {
+		url  string
+		host string
+		path string
+	}{
+		{"http://www.example.com", "www.example.com", "/"},
+		{"http://www.example.com/", "www.example.com", "/"},
+		{"http://www.example.com/foo/bar", "www.example.com", "/foo/bar"},
+		{"http://www.example.com/foo/bar/", "www.example.com", "/foo/bar/"},
+	}
+
+	for _, tt := range tests {
+		apiClient, err := getAPIClient(tt.url, "", true)
+		if err != nil {
+			t.Errorf("getAPIClient returned error %s", err)
+		}
+		transport := apiClient.Transport.(*client.Runtime)
+		if tt.host != transport.Host || tt.path != transport.BasePath {
+			t.Errorf("getAPIClient expected host %s path %s, actual host %s, path %s", tt.host, tt.path, transport.Host, transport.BasePath)
+		}
+	}
+}


### PR DESCRIPTION
Add the URL path into the transport to pass onto the API requests. Fixes #147.

Signed-off-by: Mark Peek <markpeek@vmware.com>