### PR TITLE
Fix golint issues and add to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - errcheck
     # - gofmt
     - goimports
+    - golint
     - gosimple
     - govet
     - ineffassign

--- a/vra/data_source_blueprint.go
+++ b/vra/data_source_blueprint.go
@@ -153,7 +153,7 @@ func dataSourceBlueprintRead(d *schema.ResourceData, meta interface{}) error {
 
 	id, idOk := d.GetOk("id")
 	name, nameOk := d.GetOk("name")
-	projectId, projectIdOk := d.GetOk("project_id")
+	projectID, projectIDOk := d.GetOk("project_id")
 
 	if !idOk && !nameOk {
 		return fmt.Errorf("one of id or name must be assigned")
@@ -163,8 +163,8 @@ func dataSourceBlueprintRead(d *schema.ResourceData, meta interface{}) error {
 	var err error
 	projects := make([]string, 1)
 
-	if projectIdOk {
-		projects = append(projects, projectId.(string))
+	if projectIDOk {
+		projects = append(projects, projectID.(string))
 		resp, err = apiClient.Blueprint.ListBlueprintsUsingGET1(
 			blueprint.NewListBlueprintsUsingGET1Params().WithName(withString(name.(string))).WithProjects(projects))
 	} else {

--- a/vra/data_source_catalog_item.go
+++ b/vra/data_source_catalog_item.go
@@ -115,8 +115,8 @@ func dataSourceCatalogItemRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("type", flattenResourceReference(catalogItem.Type))
 		d.Set("versions", flattenCatalogItemVersions(versions))
 
-		schemaJson, _ := json.Marshal(catalogItem.Schema)
-		d.Set("schema", string(schemaJson))
+		schemaJSON, _ := json.Marshal(catalogItem.Schema)
+		d.Set("schema", string(schemaJSON))
 	}
 
 	for _, catalogItem := range getItemsResp.Payload.Content {

--- a/vra/data_source_cloud_account_gcp_test.go
+++ b/vra/data_source_cloud_account_gcp_test.go
@@ -43,9 +43,9 @@ func TestAccDataSourceVRACloudAccountGCP(t *testing.T) {
 func testAccDataSourceVRACloudAccountGCPBase(rInt int) string {
 	// Need valid credentials since this is creating a real cloud account
 	clientEmail := os.Getenv("VRA_GCP_CLIENT_EMAIL")
-	privateKeyId := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
+	privateKeyID := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
 	privateKey := os.Getenv("VRA_GCP_PRIVATE_KEY")
-	projectId := os.Getenv("VRA_GCP_PROJECT_ID")
+	projectID := os.Getenv("VRA_GCP_PROJECT_ID")
 	return fmt.Sprintf(`
 resource "vra_cloud_account_gcp" "my-cloud-account" {
 	name = "my-cloud-account-%d"
@@ -63,7 +63,7 @@ resource "vra_cloud_account_gcp" "my-cloud-account" {
 		key = "where"
 		value = "waldo"
 	}
- }`, rInt, clientEmail, privateKeyId, privateKey, projectId)
+ }`, rInt, clientEmail, privateKeyID, privateKey, projectID)
 }
 
 func testAccDataSourceVRACloudAccountGCPNotFound(rInt int) string {

--- a/vra/data_source_network_profile_test.go
+++ b/vra/data_source_network_profile_test.go
@@ -35,7 +35,7 @@ func TestAccDataSourceVRANetworkProfile(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceVRANetworkProfileRegionIdFilter(rInt),
+				Config: testAccDataSourceVRANetworkProfileRegionIDFilter(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName1, "id", dataSourceName1, "id"),
 					resource.TestCheckResourceAttrPair(resourceName1, "description", dataSourceName1, "description"),
@@ -45,7 +45,7 @@ func TestAccDataSourceVRANetworkProfile(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceVRANetworkProfileById(rInt),
+				Config: testAccDataSourceVRANetworkProfileByID(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName1, "id", dataSourceName1, "id"),
 					resource.TestCheckResourceAttrPair(resourceName1, "description", dataSourceName1, "description"),
@@ -72,14 +72,14 @@ func testAccDataSourceVRANetworkProfileNameFilter(rInt int) string {
 	}`)
 }
 
-func testAccDataSourceVRANetworkProfileRegionIdFilter(rInt int) string {
+func testAccDataSourceVRANetworkProfileRegionIDFilter(rInt int) string {
 	return testAccCheckVRANetworkProfileConfig(rInt) + fmt.Sprintf(`
 	data "vra_network_profile" "this" {
 		filter = "regionId eq '${data.vra_region.this.id}'"
 	}`)
 }
 
-func testAccDataSourceVRANetworkProfileById(rInt int) string {
+func testAccDataSourceVRANetworkProfileByID(rInt int) string {
 	return testAccCheckVRANetworkProfileConfig(rInt) + fmt.Sprintf(`
 	data "vra_network_profile" "this" {
 		id = vra_network_profile.this.id

--- a/vra/data_source_project.go
+++ b/vra/data_source_project.go
@@ -63,23 +63,23 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 		setFields(getResp.GetPayload())
 		return nil
-	} else {
-		filter := fmt.Sprintf("name eq '%s'", name)
-		getResp, err := apiClient.Project.GetProjects(project.NewGetProjectsParams().WithDollarFilter(withString(filter)))
-
-		if err != nil {
-			return err
-		}
-
-		projects := getResp.GetPayload()
-		if len(projects.Content) > 1 {
-			return fmt.Errorf("vra_project must filter to only one project")
-		}
-		if len(projects.Content) == 0 {
-			return fmt.Errorf("project %s not found", name)
-		}
-
-		setFields(projects.Content[0])
-		return nil
 	}
+
+	filter := fmt.Sprintf("name eq '%s'", name)
+	getResp, err := apiClient.Project.GetProjects(project.NewGetProjectsParams().WithDollarFilter(withString(filter)))
+
+	if err != nil {
+		return err
+	}
+
+	projects := getResp.GetPayload()
+	if len(projects.Content) > 1 {
+		return fmt.Errorf("vra_project must filter to only one project")
+	}
+	if len(projects.Content) == 0 {
+		return fmt.Errorf("project %s not found", name)
+	}
+
+	setFields(projects.Content[0])
+	return nil
 }

--- a/vra/data_source_project_test.go
+++ b/vra/data_source_project_test.go
@@ -32,7 +32,7 @@ func TestAccDataSourceVRAProject(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataSourceVRAProjectIdConfig(rInt),
+				Config: testAccDataSourceVRAProjectIDConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName1, "description", dataSourceName2, "description"),
 					resource.TestCheckResourceAttrPair(resourceName1, "id", dataSourceName2, "id"),
@@ -66,7 +66,7 @@ func testAccDataSourceVRAProjectOneConfig(rInt int) string {
 		}`
 }
 
-func testAccDataSourceVRAProjectIdConfig(rInt int) string {
+func testAccDataSourceVRAProjectIDConfig(rInt int) string {
 	return testAccDataSourceVRAProject(rInt) + `
 		data "vra_project" "this" {
 			id = "${vra_project.my-project.id}"

--- a/vra/resource_blueprint.go
+++ b/vra/resource_blueprint.go
@@ -184,9 +184,9 @@ func resourceBlueprintRead(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*Client).apiClient
 
 	id := d.Id()
-	bpUuid := strfmt.UUID(id)
+	bpUUID := strfmt.UUID(id)
 
-	resp, err := apiClient.Blueprint.GetBlueprintUsingGET1(blueprint.NewGetBlueprintUsingGET1Params().WithBlueprintID(bpUuid))
+	resp, err := apiClient.Blueprint.GetBlueprintUsingGET1(blueprint.NewGetBlueprintUsingGET1Params().WithBlueprintID(bpUUID))
 
 	if err != nil {
 		switch err.(type) {
@@ -234,7 +234,7 @@ func resourceBlueprintUpdate(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*Client).apiClient
 
 	id := d.Id()
-	bpUuid := strfmt.UUID(id)
+	bpUUID := strfmt.UUID(id)
 	blueprintSpecification := models.Blueprint{
 		Content:         d.Get("content").(string),
 		Description:     d.Get("description").(string),
@@ -244,7 +244,7 @@ func resourceBlueprintUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	_, err := apiClient.Blueprint.UpdateBlueprintUsingPUT1(
-		blueprint.NewUpdateBlueprintUsingPUT1Params().WithBlueprintID(bpUuid).WithBlueprint(&blueprintSpecification))
+		blueprint.NewUpdateBlueprintUsingPUT1Params().WithBlueprintID(bpUUID).WithBlueprint(&blueprintSpecification))
 
 	if err != nil {
 		return err
@@ -259,9 +259,9 @@ func resourceBlueprintDelete(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*Client).apiClient
 
 	id := d.Id()
-	bpUuid := strfmt.UUID(id)
+	bpUUID := strfmt.UUID(id)
 	_, err := apiClient.Blueprint.DeleteBlueprintUsingDELETE1(
-		blueprint.NewDeleteBlueprintUsingDELETE1Params().WithBlueprintID(bpUuid))
+		blueprint.NewDeleteBlueprintUsingDELETE1Params().WithBlueprintID(bpUUID))
 	if err != nil {
 		return err
 	}

--- a/vra/resource_cloud_account_gcp_test.go
+++ b/vra/resource_cloud_account_gcp_test.go
@@ -107,8 +107,8 @@ func testAccCheckVRACloudAccountGCPDestroy(s *terraform.State) error {
 func testAccCheckVRACloudAccountGCPConfig(rInt int) string {
 	// Need valid credentials since this is creating a real cloud account
 	clientEmail := os.Getenv("VRA_GCP_CLIENT_EMAIL")
-	projectId := os.Getenv("VRA_GCP_PROJECT_ID")
-	privateKeyId := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
+	projectID := os.Getenv("VRA_GCP_PROJECT_ID")
+	privateKeyID := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
 	privateKey := os.Getenv("VRA_GCP_PRIVATE_KEY")
 	return fmt.Sprintf(`
 resource "vra_cloud_account_gcp" "my-cloud-account" {
@@ -127,14 +127,14 @@ resource "vra_cloud_account_gcp" "my-cloud-account" {
 		key = "where"
 		value = "waldo"
 	}
- }`, rInt, clientEmail, projectId, privateKeyId, privateKey)
+ }`, rInt, clientEmail, projectID, privateKeyID, privateKey)
 }
 
 func testAccCheckVRACloudAccountGCPUpdateConfig(rInt int) string {
 	// Need valid credentials since this is creating a real cloud account
 	clientEmail := os.Getenv("VRA_GCP_CLIENT_EMAIL")
-	projectId := os.Getenv("VRA_GCP_PROJECT_ID")
-	privateKeyId := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
+	projectID := os.Getenv("VRA_GCP_PROJECT_ID")
+	privateKeyID := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
 	privateKey := os.Getenv("VRA_GCP_PRIVATE_KEY")
 	return fmt.Sprintf(`
 resource "vra_cloud_account_gcp" "my-cloud-account" {
@@ -145,14 +145,14 @@ resource "vra_cloud_account_gcp" "my-cloud-account" {
 	private_key_id = "%s"
 	private_key = "%s"
 	regions = ["us-west2"]
- }`, rInt, clientEmail, projectId, privateKeyId, privateKey)
+ }`, rInt, clientEmail, projectID, privateKeyID, privateKey)
 }
 
 func testAccCheckVRACloudAccountGCPConfigDuplicateRegion(rInt int) string {
 	// Need valid credentials since this is creating a real cloud account
 	clientEmail := os.Getenv("VRA_GCP_CLIENT_EMAIL")
-	projectId := os.Getenv("VRA_GCP_PROJECT_ID")
-	privateKeyId := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
+	projectID := os.Getenv("VRA_GCP_PROJECT_ID")
+	privateKeyID := os.Getenv("VRA_GCP_PRIVATE_KEY_ID")
 	privateKey := os.Getenv("VRA_GCP_PRIVATE_KEY")
 	return fmt.Sprintf(`
 resource "vra_cloud_account_gcp" "my-cloud-account" {
@@ -163,5 +163,5 @@ resource "vra_cloud_account_gcp" "my-cloud-account" {
 	private_key_id = "%s"
 	private_key = "%s"
 	regions = ["us-west2", "us-west2"]
- }`, rInt, clientEmail, projectId, privateKeyId, privateKey)
+ }`, rInt, clientEmail, projectID, privateKeyID, privateKey)
 }

--- a/vra/resource_deployment_test.go
+++ b/vra/resource_deployment_test.go
@@ -173,7 +173,7 @@ func testAccCheckVRADeploymentDuplicateConfig(rInt int) string {
 
 func testAccCheckVRADeploymentBlueprintConfig(rInt int) string {
 	// Need valid details since this is creating a real deployment
-	blueprintId := os.Getenv("VRA_BLUEPRINT_ID")
+	blueprintID := os.Getenv("VRA_BLUEPRINT_ID")
 	blueprintVersion := os.Getenv("VRA_BLUEPRINT_VERSION")
 	projectName := os.Getenv("VRA_PROJECT_NAME")
 
@@ -189,5 +189,5 @@ func testAccCheckVRADeploymentBlueprintConfig(rInt int) string {
 	  blueprint_id = "%s"
 	  blueprint_version = "%s"
 	  project_id = data.vra_project.this.id
-	}`, projectName, rInt, blueprintId, blueprintVersion)
+	}`, projectName, rInt, blueprintID, blueprintVersion)
 }

--- a/vra/resource_load_balancer_test.go
+++ b/vra/resource_load_balancer_test.go
@@ -115,7 +115,7 @@ func testAccCheckVRALoadBalancerDestroy(s *terraform.State) error {
 func testAccCheckVRALoadBalancer(rInt int) string {
 	// Need valid credentials since this is creating a real cloud account
 	name := os.Getenv("VRA_AWS_CLOUD_ACCOUNT_NAME")
-	fabric_network := os.Getenv("VRA_FABRIC_NETWORK")
+	fabricNetwork := os.Getenv("VRA_FABRIC_NETWORK")
 	region := os.Getenv("VRA_REGION")
 	image := os.Getenv("VRA_IMAGE")
 	flavor := os.Getenv("VRA_FLAVOR")
@@ -203,7 +203,7 @@ resource "vra_machine" "my_machine" {
 	  key   = "foo"
 	  value = "bar"
 	}
-}`, name, region, rInt, rInt, fabric_network, rInt, rInt, image, rInt, flavor, rInt)
+}`, name, region, rInt, rInt, fabricNetwork, rInt, rInt, image, rInt, flavor, rInt)
 }
 
 // TODO: Enable this test when the issue https://jira.eng.vmware.com/browse/VCOM-13736 is fixed

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -354,9 +354,9 @@ func attachAndDetachDisks(d *schema.ResourceData, apiClient *client.MulticloudIa
 
 	// detach the disks one by one
 	for i, diskToDetach := range disksToDetach {
-		diskId := diskToDetach["block_device_id"].(string)
-		log.Printf("Detaching the disk %v of %v (disk id: %v) from vra_machine resource %v", i+1, len(disksToDetach), diskId, d.Get("name"))
-		deleteMachineDiskAccepted, deleteMachineDiskNoContent, err := apiClient.Disk.DeleteMachineDisk(disk.NewDeleteMachineDiskParams().WithID(id).WithId1(diskId))
+		diskID := diskToDetach["block_device_id"].(string)
+		log.Printf("Detaching the disk %v of %v (disk id: %v) from vra_machine resource %v", i+1, len(disksToDetach), diskID, d.Get("name"))
+		deleteMachineDiskAccepted, deleteMachineDiskNoContent, err := apiClient.Disk.DeleteMachineDisk(disk.NewDeleteMachineDiskParams().WithID(id).WithId1(diskID))
 
 		if err != nil {
 			return err
@@ -398,13 +398,13 @@ func attachAndDetachDisks(d *schema.ResourceData, apiClient *client.MulticloudIa
 
 	// attach the disks one by one
 	for i, diskToAttach := range disksToAttach {
-		diskId := diskToAttach["block_device_id"].(string)
-		log.Printf("Attaching the disk %v of %v (disk id: %v) to vra_machine resource %v", i+1, len(diskToAttach), diskId, d.Get("name"))
+		diskID := diskToAttach["block_device_id"].(string)
+		log.Printf("Attaching the disk %v of %v (disk id: %v) to vra_machine resource %v", i+1, len(diskToAttach), diskID, d.Get("name"))
 
 		// attach the disk if it's not already attached to machine
-		if index, _ := indexOf(diskId, diskIds); index == -1 {
+		if index, _ := indexOf(diskID, diskIds); index == -1 {
 			diskAttachmentSpecification := models.DiskAttachmentSpecification{
-				BlockDeviceID: withString(diskId),
+				BlockDeviceID: withString(diskID),
 				Description:   diskToAttach["description"].(string),
 				Name:          diskToAttach["name"].(string),
 			}
@@ -429,7 +429,7 @@ func attachAndDetachDisks(d *schema.ResourceData, apiClient *client.MulticloudIa
 				return e
 			}
 		} else {
-			log.Printf("disk %v is already attached to machine %v, moving on to the next disk to attach", diskId, id)
+			log.Printf("disk %v is already attached to machine %v, moving on to the next disk to attach", diskID, id)
 		}
 
 	}
@@ -468,14 +468,14 @@ func disksDifference(a, b []interface{}) (diff []map[string]interface{}) {
 
 	for _, item := range b {
 		diskConfig := item.(map[string]interface{})
-		blockDeviceId := diskConfig["block_device_id"].(string)
-		m[blockDeviceId] = true
+		blockDeviceID := diskConfig["block_device_id"].(string)
+		m[blockDeviceID] = true
 	}
 
 	for _, item := range a {
 		diskConfig := item.(map[string]interface{})
-		blockDeviceId := diskConfig["block_device_id"].(string)
-		if _, ok := m[blockDeviceId]; !ok {
+		blockDeviceID := diskConfig["block_device_id"].(string)
+		if _, ok := m[blockDeviceID]; !ok {
 			diff = append(diff, diskConfig)
 		}
 	}


### PR DESCRIPTION
This change enables golint within the golangci-lint suite of tests. For the most part it is renaming some variables with one additional "out-dent" of code around an "if with a return in it".

Signed-off-by: Mark Peek <markpeek@vmware.com>