### PR TITLE
Added new resource content_source, also fix for region_enumeration

### DIFF
--- a/examples/content_source/README.md
+++ b/examples/content_source/README.md
@@ -1,0 +1,27 @@
+# Content Source creation to pull a blueprint from a repository
+
+This is an example on how to create a content source linking an already existing Integration with GitLab in vRealize Automation(vRA) to pull a blueprint from repository. This allows the use of Git(Lab|Hub) as a source for bluepints and ABX scripts.
+
+This example pulls the blueprint from the blueprint01 folder in the repo at https://gitlab.com/vracontent/vra8_content_source_test
+
+## Getting Started
+
+There are variables which need to be added to terraform.tfvars.
+
+* `url` - The URL for the vRealize Automation (vRA) endpoint
+* `refresh_token` - The refresh token for the vRA account
+* `insecure` - `true` for vRA on-prem and `false` for vRA Cloud
+* `integration_id` - ID of the Git* integration to be used to connect to the repository/content
+* `project_name` - Project Name
+
+To facilitate adding these variables, a sample tfvars file can be copied first:
+```shell
+cp terraform.tfvars.sample terraform.tfvars
+```
+
+Once the information is added to `terraform.tfvars`, the cloud account can be brought up via:
+
+```shell
+terraform init
+terraform apply
+```

--- a/examples/content_source/main.tf
+++ b/examples/content_source/main.tf
@@ -1,0 +1,29 @@
+provider "vra" {
+  url           = var.url
+  refresh_token = var.refresh_token
+  insecure      = var.insecure
+}
+
+resource "vra_project" "this" {
+  name = var.project_name
+}
+
+resource "vra_content_source" "this" {
+  name       = var.content_source_name
+  project_id = vra_project.this.id
+  // type_id needs to be one of com.gitlab, com.github or com.vmware.marketplace
+  type_id     = "com.gitlab"
+  description = "Some content Source"
+  //whether automatically sync content or not
+  sync_enabled = "false"
+  config {
+    path           = "blueprint01"
+    branch         = "master"
+    repository     = "vracontent/vra8_content_source_test"
+    content_type   = "BLUEPRINT"
+    project_name   = var.project_name
+    integration_id = var.integration_id
+  }
+
+
+}

--- a/examples/content_source/terraform.tfvars.sample
+++ b/examples/content_source/terraform.tfvars.sample
@@ -1,0 +1,7 @@
+refresh_token = ""
+url = ""
+insecure = ""
+content_source_name = ""
+integration_id = ""
+project_name = ""
+

--- a/examples/content_source/variables.tf
+++ b/examples/content_source/variables.tf
@@ -1,0 +1,22 @@
+variable "url" {
+  description = "URL for reaching the vRA Cloud/vRA8 instance"
+}
+variable "refresh_token" {
+  description = "Refresh token"
+}
+
+variable "insecure" {
+  description = "Whether to allow for self-signed certs set true for vRA8 on prem, false for SaaS"
+}
+
+variable "integration_id" {
+  description = "ID of the Gitlab/Github integration that should be used to access the repository"
+}
+
+variable "content_source_name" {
+  description = "Name of the new content source"
+}
+
+variable "project_name" {
+  description = "Name of the new project"
+}

--- a/examples/content_source/versions.tf
+++ b/examples/content_source/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/vra/content_source_repository_config.go
+++ b/vra/content_source_repository_config.go
@@ -1,0 +1,52 @@
+package vra
+
+import (
+	"reflect"
+)
+
+// ContentSourceRepositoryConfig - Config fields for linking an SCM integration
+// with a repository and project not included in the swagger model so we're hand crafting it
+type ContentSourceRepositoryConfig struct {
+	Path          string `json:"path,omitempty"`
+	Branch        string `json:"branch,omitempty"`
+	Repository    string `json:"repository,omitempty"`
+	ContentType   string `json:"contentType,omitempty"`
+	ProjectName   string `json:"projectName,omitempty"`
+	IntegrationID string `json:"integrationId,omitempty"`
+}
+
+// treating the config elem as an array rather than a singleton
+func expandContentSourceRepositoryConfig(repoConfigs []interface{}) []*ContentSourceRepositoryConfig {
+	configs := make([]*ContentSourceRepositoryConfig, 0, len(repoConfigs))
+
+	for _, repo := range repoConfigs {
+		config := repo.(map[string]interface{})
+
+		cfg := ContentSourceRepositoryConfig{
+			Path:          config["path"].(string),
+			Branch:        config["branch"].(string),
+			Repository:    config["repository"].(string),
+			ContentType:   config["content_type"].(string),
+			ProjectName:   config["project_name"].(string),
+			IntegrationID: config["integration_id"].(string),
+		}
+
+		configs = append(configs, &cfg)
+	}
+	return configs
+}
+
+//Convert from json back to an array
+func flattenContentsourceRepositoryConfig(list interface{}) []map[string]interface{} {
+	l := map[string]interface{}{}
+	v := reflect.ValueOf(list)
+	if v.Kind() == reflect.Map {
+		for _, key := range v.MapKeys() {
+			strct := v.MapIndex(key)
+			l[key.String()] = strct.Interface()
+		}
+	}
+	result := make([]map[string]interface{}, 0, 1)
+	result = append(result, l)
+	return result
+}

--- a/vra/provider.go
+++ b/vra/provider.go
@@ -80,6 +80,7 @@ func Provider() *schema.Provider {
 			"vra_cloud_account_nsxv":    resourceCloudAccountNSXV(),
 			"vra_cloud_account_vmc":     resourceCloudAccountVMC(),
 			"vra_cloud_account_vsphere": resourceCloudAccountVsphere(),
+			"vra_content_source":        resourceContentSource(),
 			"vra_deployment":            resourceDeployment(),
 			"vra_flavor_profile":        resourceFlavorProfile(),
 			"vra_image_profile":         resourceImageProfile(),

--- a/vra/provider_test.go
+++ b/vra/provider_test.go
@@ -378,3 +378,23 @@ func testAccPreCheckVra(t *testing.T) {
 		t.Fatal("VRA_REFRESH_TOKEN or VRA_ACCESS_TOKEN must be set for acceptance tests")
 	}
 }
+
+func testAccPreCheckContentSource(t *testing.T) {
+	if os.Getenv("VRA_REFRESH_TOKEN") == "" && os.Getenv("VRA_ACCESS_TOKEN") == "" {
+		t.Fatal("VRA_REFRESH_TOKEN or VRA_ACCESS_TOKEN must be set for acceptance tests")
+	}
+
+	envVars := [...]string{
+		"VRA_URL",
+		"VRA_INTEGRATION_ID",
+		"VRA_CONTENT_SOURCE_PATH",
+		"VRA_CONTENT_SOURCE_BRANCH",
+		"VRA_CONTENT_SOURCE_REPO",
+	}
+
+	for _, name := range envVars {
+		if v := os.Getenv(name); v == "" {
+			t.Fatalf("%s must be set for acceptance tests\n", name)
+		}
+	}
+}

--- a/vra/resource_content_source.go
+++ b/vra/resource_content_source.go
@@ -1,0 +1,219 @@
+package vra
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/vmware/vra-sdk-go/pkg/client/content_source"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"log"
+)
+
+func resourceContentSource() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceContentSourceCreate,
+		Read:   resourceContentSourceRead,
+		Delete: resourceContentSourceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type_id": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"com.gitlab", "com.github", "com.vmware.marketplace"}, true),
+			},
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			//project_ids exists in the model but isn't actually fed back in a read operation
+			//"project_ids": &schema.Schema{
+			//	Type:     schema.TypeList,
+			//	Optional: true,
+			//	ForceNew: true,
+			//	Elem: &schema.Schema{
+			//		Type: schema.TypeString,
+			//	},
+			//},
+			"created_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_updated_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_updated_by": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			//Treating this as a set requires us to do some gymnastics later with expanding/flattening
+			"config": &schema.Schema{
+				Type:     schema.TypeSet,
+				MaxItems: 1,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"branch": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"repository": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"content_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"BLUEPRINT", "IMAGE", "ABX_SCRIPTS"}, true),
+						},
+						"project_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"integration_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"sync_enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceContentSourceCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to create vra_ContentSource resource3")
+
+	var projectIds []string
+	apiClient := m.(*Client).apiClient
+
+	name := d.Get("name").(string)
+	typeID := d.Get("type_id").(string)
+	projectID := d.Get("project_id").(string)
+
+	config := expandContentSourceRepositoryConfig(d.Get("config").(*schema.Set).List())
+
+	if v, ok := d.GetOk("project_ids"); ok {
+		if !compareUnique(v.([]interface{})) {
+			return fmt.Errorf("Specified project_ids are not unique")
+		}
+		projectIds = expandStringList(v.([]interface{}))
+	}
+	contentSourceSpecification := models.ContentSource{
+		Name:        &name,
+		TypeID:      &typeID,
+		Config:      config[0],
+		ProjectIds:  projectIds,
+		ProjectID:   &projectID,
+		SyncEnabled: d.Get("sync_enabled").(bool),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		contentSourceSpecification.Description = v.(string)
+	}
+
+	resp, err := apiClient.ContentSource.CreateContentSourceUsingPOST(content_source.NewCreateContentSourceUsingPOSTParams().WithSource(&contentSourceSpecification))
+
+	if err != nil {
+		return err
+	}
+
+	id := *resp.GetPayload().ID
+	d.SetId(id.String())
+
+	log.Printf("Finished creating vra_ContentSource resource with name %s", d.Get("name"))
+
+	return resourceContentSourceRead(d, m)
+}
+
+func resourceContentSourceRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Reading the vra_ContentSource resource with name %s", d.Get("name"))
+	apiClient := m.(*Client).apiClient
+
+	id := d.Id()
+	csUUID := strfmt.UUID(id)
+
+	resp, err := apiClient.ContentSource.GetContentSourceUsingGET(content_source.NewGetContentSourceUsingGETParams().WithID(csUUID))
+
+	if err != nil {
+		switch err.(type) {
+		case *content_source.GetContentSourceUsingGETNotFound:
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	ContentSource := *resp.Payload
+	d.Set("config", flattenContentsourceRepositoryConfig(ContentSource.Config))
+	d.Set("id", ContentSource.ID)
+	d.Set("last_updated_at", ContentSource.LastUpdatedAt)
+	d.Set("last_updated_by", ContentSource.LastUpdatedBy)
+	d.Set("created_at", ContentSource.CreatedAt)
+	d.Set("created_by", ContentSource.CreatedBy)
+	d.Set("description", ContentSource.Description)
+	d.Set("name", ContentSource.Name)
+	d.Set("org_id", ContentSource.OrgID)
+	d.Set("project_id", ContentSource.ProjectID)
+	d.Set("project_ids", ContentSource.ProjectIds)
+
+	d.Set("sync_enabled", ContentSource.SyncEnabled)
+	d.Set("type", ContentSource.Type)
+	d.Set("type_id", ContentSource.TypeID)
+
+	log.Printf("Finished reading the vra_ContentSource resource with name %s", d.Get("name"))
+	return nil
+}
+
+func resourceContentSourceDelete(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to delete the vra_ContentSource resource with name %s", d.Get("name"))
+	apiClient := m.(*Client).apiClient
+
+	id := d.Id()
+	csUUID := strfmt.UUID(id)
+	_, err := apiClient.ContentSource.DeleteContentSourceUsingDELETE(content_source.NewDeleteContentSourceUsingDELETEParams().WithID(csUUID))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	log.Printf("Finished deleting the vra_ContentSource resource with name %s", d.Get("name"))
+	return nil
+}

--- a/vra/resource_content_source_test.go
+++ b/vra/resource_content_source_test.go
@@ -1,0 +1,168 @@
+package vra
+
+import (
+	"fmt"
+	"os"
+
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/vmware/vra-sdk-go/pkg/client/content_source"
+)
+
+func TestAccVRAContentSource_Valid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_content_source.this"
+	project := "vra_project.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckContentSource(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRAContentSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRAContentSourceValidConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVRAContentSourceExists(resource1),
+					resource.TestMatchResourceAttr(resource1, "name", regexp.MustCompile("^test-cs-"+strconv.Itoa(rInt))),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", project, "id"),
+					resource.TestCheckResourceAttr(resource1, "description", "terraform test content_source"),
+					resource.TestCheckResourceAttr(resource1, "type_id", "com.gitlab"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVRAContentSource_Invalid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckContentSource(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRAContentSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckVRAContentSourceInvalidConfigContentType(rInt),
+				ExpectError: regexp.MustCompile("content_type to be one of"),
+			},
+			{
+				Config:      testAccCheckVRAContentSourceInvalidTypeID(rInt),
+				ExpectError: regexp.MustCompile("expected type_id to be one of"),
+			},
+		},
+	})
+}
+
+func testAccCheckVRAContentSourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no content_source ID is set")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckVRAContentSourceDestroy(s *terraform.State) error {
+	apiClient := testAccProviderVRA.Meta().(*Client).apiClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vra_content_source" {
+			continue
+		}
+
+		_, err := apiClient.ContentSource.GetContentSourceUsingGET(content_source.NewGetContentSourceUsingGETParams().WithID(strfmt.UUID(rs.Primary.ID)))
+
+		if err == nil {
+			return fmt.Errorf("resource 'vra_content_source' still exists with id %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVRAContentSourceValidConfig(rInt int) string {
+	integrationID := os.Getenv("VRA_INTEGRATION_ID")
+	repoFolder := os.Getenv("VRA_CONTENT_SOURCE_PATH")
+	repoBranch := os.Getenv("VRA_CONTENT_SOURCE_BRANCH")
+	repo := os.Getenv("VRA_CONTENT_SOURCE_REPO")
+
+	return fmt.Sprintf(`
+	resource "vra_project" "this" {
+		name = "terraform-test-project %d"
+	  }
+
+	resource "vra_content_source" "this" {
+	  name        = "test-cs-%d"
+	  description = "terraform test content_source"
+	  project_id = vra_project.this.id
+	  type_id = "com.gitlab"
+	  sync_enabled = "false"
+	  config  {
+			path = "%s"
+			branch = "%s"
+			repository = "%s"
+			content_type = "BLUEPRINT"
+			project_name = vra_project.this.name
+			integration_id = "%s"
+			}
+	  }`, rInt, rInt, repoFolder, repoBranch, repo, integrationID)
+}
+
+func testAccCheckVRAContentSourceInvalidConfigContentType(rInt int) string {
+	integrationID := os.Getenv("VRA_INTEGRATION_ID")
+	repoFolder := os.Getenv("VRA_CONTENT_SOURCE_PATH")
+	repoBranch := os.Getenv("VRA_CONTENT_SOURCE_BRANCH")
+	repo := os.Getenv("VRA_CONTENT_SOURCE_REPO")
+
+	return fmt.Sprintf(`
+	resource "vra_content_source" "this" {
+		name        = "test-cs-%d"
+		description = "terraform test content_source"
+		project_id = "9704b10f-ffff-aaaa-bbbb-7799029197d3"
+		type_id = "com.gitlab"
+		sync_enabled = "true"
+		config  {
+			  path = "%s"
+			  branch=  "%s"
+			  repository=  "%s"
+			  content_type= "PANCAKE"
+			  project_name= "some random name"
+			  integration_id= "%s"
+			  }
+		}`, rInt, repoFolder, repoBranch, repo, integrationID)
+}
+
+func testAccCheckVRAContentSourceInvalidTypeID(rInt int) string {
+	integrationID := os.Getenv("VRA_INTEGRATION_ID")
+	repoFolder := os.Getenv("VRA_CONTENT_SOURCE_PATH")
+	repoBranch := os.Getenv("VRA_CONTENT_SOURCE_BRANCH")
+	repo := os.Getenv("VRA_CONTENT_SOURCE_REPO")
+
+	return fmt.Sprintf(`
+	resource "vra_content_source" "this" {
+	  name        = "test-cs-%d"
+	  description = "terraform test content_source"
+	  project_id = "9704b10f-ffff-aaaa-bbbb-7799029197d3"
+	  type_id = "com.subversion"
+	  sync_enabled = "true"
+	  config  {
+			path = "%s"
+			branch = "%s"
+			repository = "%s"
+			content_type = "BLUEPRINT"
+			project_name = "some random name"
+			integration_id = "%s"
+			}
+	  }`, rInt, repoFolder, repoBranch, repo, integrationID)
+}


### PR DESCRIPTION
This PR adds support for a new resource ```vra_content_source``` leveraging the recent addition of the content api to vra-sdk-go. 
I've included an example, tests, and also a new struct ```ContentSourceRepositoryConfig``` in a standalone file to handle the content source repository config because it's required but not explicitly in the swagger model. 

This PR also includes a modified version of ```vra/data_source_region_enumeration.go``` as one of the side effects of the swagger hacks fix for region_enumeration in vra-sdk-go (https://github.com/vmware/vra-sdk-go/pull/12) resulted in a change in to the EnumerateVSphereRegions call from: 

```go
func (a *Client) EnumerateVSphereRegions(params *EnumerateVSphereRegionsParams) (*EnumerateVSphereRegionsOK, error) {
```
to: 

```go
func (a *Client) EnumerateVSphereRegions(params *EnumerateVSphereRegionsParams) (*EnumerateVSphereRegionsOK, *EnumerateVSphereRegionsCreated, error) {
```
so the call went from returning two values to three. So the change to handle this is also included otherwise I wasn't able to build. Since I was already modifying this particular file,  I included the equivalent of #143 

@markpeek, @dmettem This may also require a new release of vra-sdk-go that includes the recent changes to compile? 

-CRT 

Signed-off-by: Carlos Tronco cars@lostroncos.org
