### PR TITLE
Add version information to binary file

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ build_providers() {
     rm -rf build
     mkdir build
     GO111MODULE=on CGO_ENABLED=0 gox -ldflags "-X main.version=${VERSION} -X main.buildTime=${NOWDATE}" \
-        -os "linux darwin windows" -arch "amd64" -output "build/{{.OS}}_{{.Arch}}/terraform-provider-vra"
+        -os "linux darwin windows" -arch "amd64" -output "build/{{.OS}}_{{.Arch}}/terraform-provider-vra_${VERSION}"
     if [ $? -ne 0 ]; then
         echo "Error building providers...exiting"
         exit 1


### PR DESCRIPTION
Add version information to plugin file so that terraform can display the
version when 'terraform -version' command is run.

Sample:
$ terraform -version
Terraform v0.12.21
+ provider.vra v0.1.8-6-g9b5854c

Fixes the issue #171.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>