### PR TITLE
Increase request timeouts for slow requests

### DIFF
--- a/vra/client.go
+++ b/vra/client.go
@@ -6,6 +6,7 @@ import (
 	neturl "net/url"
 	"os"
 	"strings"
+	"time"
 
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
@@ -24,6 +25,8 @@ type Client struct {
 const (
 	CatalogAPIVersion = "2019-01-15"
 )
+
+const IncreasedTimeOut = 60 * time.Second
 
 // NewClientFromRefreshToken configures and returns a VRA "Client" struct using "refresh_token" from provider config
 func NewClientFromRefreshToken(url, refreshToken string, insecure bool) (interface{}, error) {

--- a/vra/data_source_deployment.go
+++ b/vra/data_source_deployment.go
@@ -187,9 +187,12 @@ func dataSourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 
 	// Get the deployment details with all the user provided flags
 	getResp, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
-		deployments.NewGetDeploymentByIDUsingGETParams().WithDepID(strfmt.UUID(id.(string))).
-			WithExpandProject(withBool(expandProject)).WithExpandResources(withBool(expandResources)).
-			WithExpandLastRequest(withBool(expandLastRequest)))
+		deployments.NewGetDeploymentByIDUsingGETParams().
+			WithDepID(strfmt.UUID(id.(string))).
+			WithExpandProject(withBool(expandProject)).
+			WithExpandResources(withBool(expandResources)).
+			WithExpandLastRequest(withBool(expandLastRequest)).
+			WithTimeout(IncreasedTimeOut))
 
 	if err != nil {
 		return err

--- a/vra/data_source_region_enumeration_vmc.go
+++ b/vra/data_source_region_enumeration_vmc.go
@@ -55,15 +55,18 @@ func dataSourceRegionEnumerationVMC() *schema.Resource {
 func dataSourceRegionEnumerationVMCRead(d *schema.ResourceData, meta interface{}) error {
 	apiClient := meta.(*Client).apiClient
 
-	getResp, err := apiClient.CloudAccount.EnumerateVmcRegions(cloud_account.NewEnumerateVmcRegionsParams().WithBody(&models.CloudAccountVmcSpecification{
-		AcceptSelfSignedCertificate: d.Get("accept_self_signed_cert").(bool),
-		APIKey:                      d.Get("api_token").(string),
-		DcID:                        d.Get("dc_id").(string),
-		HostName:                    withString(d.Get("vcenter_hostname").(string)),
-		Password:                    withString(d.Get("vcenter_password").(string)),
-		SddcID:                      d.Get("sddc_name").(string),
-		Username:                    withString(d.Get("vcenter_username").(string)),
-	}))
+	getResp, err := apiClient.CloudAccount.EnumerateVmcRegions(
+		cloud_account.NewEnumerateVmcRegionsParams().
+			WithTimeout(IncreasedTimeOut).
+			WithBody(&models.CloudAccountVmcSpecification{
+				AcceptSelfSignedCertificate: d.Get("accept_self_signed_cert").(bool),
+				APIKey:                      d.Get("api_token").(string),
+				DcID:                        d.Get("dc_id").(string),
+				HostName:                    withString(d.Get("vcenter_hostname").(string)),
+				Password:                    withString(d.Get("vcenter_password").(string)),
+				SddcID:                      d.Get("sddc_name").(string),
+				Username:                    withString(d.Get("vcenter_username").(string)),
+			}))
 
 	if err != nil {
 		return err

--- a/vra/data_source_region_enumeration_vsphere.go
+++ b/vra/data_source_region_enumeration_vsphere.go
@@ -47,13 +47,16 @@ func dataSourceRegionEnumerationVsphere() *schema.Resource {
 func dataSourceRegionEnumerationVsphereRead(d *schema.ResourceData, meta interface{}) error {
 	apiClient := meta.(*Client).apiClient
 
-	getResp, err := apiClient.CloudAccount.EnumerateVSphereRegions(cloud_account.NewEnumerateVSphereRegionsParams().WithBody(&models.CloudAccountVsphereSpecification{
-		AcceptSelfSignedCertificate: d.Get("accept_self_signed_cert").(bool),
-		Dcid:                        d.Get("dcid").(string),
-		HostName:                    withString(d.Get("hostname").(string)),
-		Password:                    withString(d.Get("password").(string)),
-		Username:                    withString(d.Get("username").(string)),
-	}))
+	getResp, err := apiClient.CloudAccount.EnumerateVSphereRegions(
+		cloud_account.NewEnumerateVSphereRegionsParams().
+			WithTimeout(IncreasedTimeOut).
+			WithBody(&models.CloudAccountVsphereSpecification{
+				AcceptSelfSignedCertificate: d.Get("accept_self_signed_cert").(bool),
+				Dcid:                        d.Get("dcid").(string),
+				HostName:                    withString(d.Get("hostname").(string)),
+				Password:                    withString(d.Get("password").(string)),
+				Username:                    withString(d.Get("username").(string)),
+			}))
 
 	if err != nil {
 		return err

--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -374,9 +374,12 @@ func resourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 	expandProject := d.Get("expand_project").(bool)
 
 	resp, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
-		deployments.NewGetDeploymentByIDUsingGETParams().WithDepID(strfmt.UUID(id)).
-			WithExpandResources(withBool(true)).WithExpandLastRequest(withBool(true)).
-			WithExpandProject(withBool(expandProject)))
+		deployments.NewGetDeploymentByIDUsingGETParams().
+			WithDepID(strfmt.UUID(id)).
+			WithExpandResources(withBool(true)).
+			WithExpandLastRequest(withBool(true)).
+			WithExpandProject(withBool(expandProject)).
+			WithTimeout(IncreasedTimeOut))
 	if err != nil {
 		switch err.(type) {
 		case *deployments.GetDeploymentByIDUsingGETNotFound:
@@ -651,8 +654,10 @@ func runAction(d *schema.ResourceData, apiClient *client.MulticloudIaaS, deploym
 func deploymentActionStatusRefreshFunc(apiClient client.MulticloudIaaS, deploymentUUID strfmt.UUID, requestID strfmt.UUID) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		ret, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
-			deployments.NewGetDeploymentByIDUsingGETParams().WithDepID(deploymentUUID).
-				WithExpandLastRequest(withBool(true)))
+			deployments.NewGetDeploymentByIDUsingGETParams().
+				WithDepID(deploymentUUID).
+				WithExpandLastRequest(withBool(true)).
+				WithTimeout(IncreasedTimeOut))
 		if err != nil {
 			return "", models.DeploymentRequestStatusFAILED, err
 		}


### PR DESCRIPTION
Region enumeration requests for vSphere and VMC sometime may take longer than
the default timeout of 30 seconds. Same is the case for deployment read
requests with expand resources, lastRequest, and Projects.

This commit increases the timeout for these requests from default 30 seconds
to 60 seconds.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>