### PR TITLE
Persist state for deployments that failed mid-flight

### DIFF
--- a/examples/deployment/blueprint/main.tf
+++ b/examples/deployment/blueprint/main.tf
@@ -25,6 +25,12 @@ resource "vra_deployment" "this" {
     count  = 2
     flag   = true
   }
+
+  timeouts {
+    create = "30m"
+    delete = "30m"
+    update = "30m"
+  }
 }
 
 

--- a/examples/deployment/catalog_item/main.tf
+++ b/examples/deployment/catalog_item/main.tf
@@ -27,6 +27,12 @@ resource "vra_deployment" "this" {
     count  = 1
     flag   = false
   }
+
+  timeouts {
+    create = "30m"
+    delete = "30m"
+    update = "30m"
+  }
 }
 
 output "resources" {

--- a/vra/data_source_deployment.go
+++ b/vra/data_source_deployment.go
@@ -82,7 +82,7 @@ func dataSourceDeployment() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			//TODO: add last_request
+			"last_request": deploymentRequestSchema(),
 			"last_updated_at": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -136,28 +136,19 @@ func dataSourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 
 	setFields := func(deployment *models.Deployment) error {
 		d.SetId(deployment.ID.String())
-		d.Set("name", deployment.Name)
-		d.Set("description", deployment.Description)
 		d.Set("blueprint_id", deployment.BlueprintID)
 		d.Set("blueprint_version", deployment.BlueprintVersion)
 		d.Set("catalog_item_id", deployment.CatalogItemID)
 		d.Set("catalog_item_version", deployment.CatalogItemVersion)
 		d.Set("created_at", deployment.CreatedAt)
 		d.Set("created_by", deployment.CreatedBy)
-		//TODO: Set last_request
+		d.Set("description", deployment.Description)
 		d.Set("last_updated_at", deployment.LastUpdatedAt)
 		d.Set("last_updated_by", deployment.LastUpdatedBy)
 		d.Set("lease_expire_at", deployment.LeaseExpireAt)
+		d.Set("name", deployment.Name)
 		d.Set("project_id", deployment.ProjectID)
 		d.Set("status", deployment.Status)
-
-		if err := d.Set("project", flattenResourceReference(deployment.Project)); err != nil {
-			return fmt.Errorf("error setting project in deployment - error: %#v", err)
-		}
-
-		if err := d.Set("resources", flattenResources(deployment.Resources)); err != nil {
-			return fmt.Errorf("error setting resources in deployment - error: %#v", err)
-		}
 
 		if err := d.Set("expense", flattenExpense(deployment.Expense)); err != nil {
 			return fmt.Errorf("error setting deployment expense - error: %#v", err)
@@ -165,6 +156,18 @@ func dataSourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 
 		if err := d.Set("inputs", expandInputs(deployment.Inputs)); err != nil {
 			return fmt.Errorf("error setting deployment inputs - error: %#v", err)
+		}
+
+		if err := d.Set("last_request", flattenDeploymentRequest(deployment.LastRequest)); err != nil {
+			return fmt.Errorf("error setting deployment last_request - error: %#v", err)
+		}
+
+		if err := d.Set("project", flattenResourceReference(deployment.Project)); err != nil {
+			return fmt.Errorf("error setting project in deployment - error: %#v", err)
+		}
+
+		if err := d.Set("resources", flattenResources(deployment.Resources)); err != nil {
+			return fmt.Errorf("error setting resources in deployment - error: %#v", err)
 		}
 		return nil
 	}

--- a/vra/data_source_deployment_test.go
+++ b/vra/data_source_deployment_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
-	"os"
 	"regexp"
 	"testing"
 )
@@ -21,7 +20,7 @@ func TestAccDataSourceVRADeployment(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDataSourceVRADeploymentNoneConfig(rInt),
+				Config:      testAccDataSourceVRADeploymentNoneConfig(),
 				ExpectError: regexp.MustCompile("deployment invalid-name not found"),
 			},
 			{
@@ -31,7 +30,7 @@ func TestAccDataSourceVRADeployment(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName1, "id", dataSourceName1, "id"),
 					resource.TestCheckResourceAttrPair(resourceName1, "name", dataSourceName1, "name"),
 					resource.TestCheckResourceAttrPair(resourceName1, "project_id", dataSourceName1, "project_id"),
-					resource.TestCheckResourceAttrPair(resourceName1, "catalog_item_id", dataSourceName1, "catalog_item_id"),
+					resource.TestCheckResourceAttrPair(resourceName1, "blueprint_id", dataSourceName1, "blueprint_id"),
 				),
 			},
 		},
@@ -39,31 +38,35 @@ func TestAccDataSourceVRADeployment(t *testing.T) {
 }
 
 func testAccDataSourceVRADeployment(rInt int) string {
-	// Need valid details since this is creating a real deployment
-	catalogItemName := os.Getenv("VRA_CATALOG_ITEM_NAME")
-	projectName := os.Getenv("VRA_PROJECT_NAME")
-
 	return fmt.Sprintf(`
-	data "vra_project" "this" {
-	  name = "%s"
+	resource "vra_project" "this" {
+	  name = "terraform-test-project-%d"
 	}
 
-	data "vra_catalog_item" "this" {
-	  name = "%s"
+	resource "vra_blueprint" "this" {
+	  name        = "test-blueprint-%d"
+	  description = "terraform test blueprint"
+
+	  project_id = vra_project.this.id
+
+	  content = <<-EOT
+				 formatVersion: 1
+				 inputs: {}
+				 resources:  {}
+				EOT
 	}
 
 	resource "vra_deployment" "this" {
 	  name        = "test-deployment-%d"
 	  description = "terraform test deployment"
 
-	  catalog_item_id = data.vra_catalog_item.this.id
-	  project_id = data.vra_project.this.id
-	}`, projectName, catalogItemName, rInt)
+	  blueprint_id = vra_blueprint.this.id
+	  project_id = vra_project.this.id
+	}`, rInt, rInt, rInt)
 }
 
-func testAccDataSourceVRADeploymentNoneConfig(rInt int) string {
-	return testAccDataSourceVRADeployment(rInt) + `
-		data "vra_deployment" "this" {
+func testAccDataSourceVRADeploymentNoneConfig() string {
+	return `data "vra_deployment" "invalid" {
 			name = "invalid-name"
 		}`
 }

--- a/vra/deployment_request.go
+++ b/vra/deployment_request.go
@@ -1,0 +1,164 @@
+package vra
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+)
+
+// deploymentRequest returns the schema to use for the last_request property
+func deploymentRequestSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"action_id": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"approved_at": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"blueprint_id": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"cancelable": &schema.Schema{
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"catalog_item_id": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"completed_at": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"completed_tasks": &schema.Schema{
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"created_at": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"deployment_id": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"details": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"dismissed": &schema.Schema{
+					Type:     schema.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+				"id": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"initialized_at": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"inputs": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"name": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"parent_id": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"requested_by": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"resource_name": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"resource_type": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"status": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"total_tasks": &schema.Schema{
+					Type:     schema.TypeInt,
+					Optional: true,
+					Computed: true,
+				},
+				"updated_at": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func flattenDeploymentRequest(deploymentRequest *models.DeploymentRequest) interface{} {
+	if deploymentRequest == nil {
+		return make([]interface{}, 0)
+	}
+
+	helper := make(map[string]interface{})
+
+	helper["action_id"] = deploymentRequest.ActionID
+	helper["approved_at"] = deploymentRequest.ApprovedAt.String()
+	helper["blueprint_id"] = deploymentRequest.BlueprintID
+	helper["cancelable"] = deploymentRequest.Cancelable
+	helper["catalog_item_id"] = deploymentRequest.CatalogItemID
+	helper["completed_at"] = deploymentRequest.CompletedAt.String()
+	helper["completed_tasks"] = deploymentRequest.CompletedTasks
+	helper["created_at"] = deploymentRequest.CreatedAt.String()
+	helper["deployment_id"] = deploymentRequest.DeploymentID.String()
+	helper["details"] = deploymentRequest.Details
+	helper["dismissed"] = deploymentRequest.Dismissed
+	helper["id"] = deploymentRequest.ID.String()
+	helper["initialized_at"] = deploymentRequest.InitializedAt.String()
+	helper["inputs"] = expandInputs(deploymentRequest.Inputs)
+	helper["name"] = deploymentRequest.Name
+	helper["parent_id"] = deploymentRequest.ParentID.String()
+	helper["requested_by"] = deploymentRequest.RequestedBy
+	helper["resource_name"] = deploymentRequest.ResourceName
+	helper["resource_type"] = deploymentRequest.ResourceType
+	helper["status"] = deploymentRequest.Status
+	helper["total_tasks"] = deploymentRequest.TotalTasks
+	helper["updated_at"] = deploymentRequest.UpdatedAt.String()
+
+	return []interface{}{helper}
+}

--- a/vra/provider_test.go
+++ b/vra/provider_test.go
@@ -344,8 +344,6 @@ func testAccPreCheckDeploymentDataSource(t *testing.T) {
 
 	envVars := [...]string{
 		"VRA_URL",
-		"VRA_CATALOG_ITEM_NAME",
-		"VRA_PROJECT_NAME",
 	}
 
 	for _, name := range envVars {

--- a/vra/resource_project.go
+++ b/vra/resource_project.go
@@ -42,6 +42,7 @@ func resourceProject() *schema.Resource {
 			"shared_resources": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 			"zone_assignments": &schema.Schema{
 				Type:     schema.TypeSet,


### PR DESCRIPTION
For deployments failed mid-flight, state is not persisted correctly causing
the refresh to fail. This commit ensures that a deployment id is persisted
during create, so that even if the deployment fails or timesout, the
deployment resource is still created in the state and refresh works.

In case the provider times out before the deployment request completes i.e
successful or failed, refresh will pull the latest state of deployment.
For in-place updates of such deployment resources that timed out during
create should be untainted first.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>