### PR TITLE
Fail early if deployment update is requested but not avaialble

### DIFF
--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -483,10 +483,14 @@ func runDeploymentUpdateAction(d *schema.ResourceData, apiClient *client.Multicl
 	actionID := ""
 	for _, action := range deploymentActions.Payload {
 		if strings.Contains(strings.ToLower(action.ID), strings.ToLower("Update")) {
-			// Update action is available on the deployment
-			updateAvailable = true
-			actionID = action.ID
-			break
+			if action.Valid {
+				log.Printf("[DEBUG] update action is available on the deployment")
+				updateAvailable = true
+				actionID = action.ID
+				break
+			} else {
+				return fmt.Errorf("noticed changes to inputs, but 'Update' action is not supported based on the current state of the deployment")
+			}
 		}
 	}
 


### PR DESCRIPTION
If inputs are changed in a deployment but the update action is not available
based on the current state of the deployment, the apply command fails immediately
without actually requesting for update action and getting failure from the service.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>