### PR TITLE
Allow NSX-T/V accounts association with vSphere

### DIFF
--- a/examples/cloud_account_vsphere/README.md
+++ b/examples/cloud_account_vsphere/README.md
@@ -8,9 +8,12 @@ There are variables which need to be added to terraform.tfvars. The first are fo
 
 * `url` - The URL for the vRealize Automation (vRA) endpoint
 * `refresh_token` - The refresh token for the vRA account
-* `username` - username for vCenter
-* `password` - password for vCenter
-* `hostname` - hostname for vCenter
+* `username` - username for vCenter server
+* `password` - password for vCenter server
+* `hostname` - hostname for vCenter server
+* `nsxt_username` - username for NSX-T
+* `nsxt_password` - password for NSX-T
+* `nsxt_hostname` - hostname for NSX-T
 * `datacollector` - the name for the data collector already setup for the vCenter account
 
 To facilitate adding these variables, a sample tfvars file can be copied first:

--- a/examples/cloud_account_vsphere/main.tf
+++ b/examples/cloud_account_vsphere/main.tf
@@ -10,6 +10,22 @@ data "vra_data_collector" "dc" {
   name  = var.datacollector
 }
 
+resource "vra_cloud_account_nsxt" "this" {
+  name        = "tf-nsx-t-account"
+  description = "foobar"
+  username    = var.nsxt_username
+  password    = var.nsxt_password
+  hostname    = var.nsxt_hostname
+  dc_id       = var.datacollector != "" ? data.vra_data_collector.dc[0].id : "" // Required for vRA Cloud, Optional for vRA 8.0
+
+  accept_self_signed_cert = true
+
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+
 data "vra_region_enumeration_vsphere" "this" {
   username                = var.username
   password                = var.password
@@ -26,8 +42,9 @@ resource "vra_cloud_account_vsphere" "this" {
   hostname    = var.hostname
   dcid        = var.datacollector != "" ? data.vra_data_collector.dc[0].id : "" // Required for vRA Cloud, Optional for vRA 8.0
 
-  regions                 = data.vra_region_enumeration_vsphere.this.regions
-  accept_self_signed_cert = true
+  regions                      = data.vra_region_enumeration_vsphere.this.regions
+  associated_cloud_account_ids = [vra_cloud_account_nsxt.this.id]
+  accept_self_signed_cert      = true
 
   tags {
     key   = "foo"

--- a/examples/cloud_account_vsphere/variables.tf
+++ b/examples/cloud_account_vsphere/variables.tf
@@ -5,7 +5,6 @@ variable "url" {
 }
 
 variable "insecure" {
-
 }
 
 variable "username" {
@@ -20,3 +19,11 @@ variable "hostname" {
 variable "datacollector" {
 }
 
+variable "nsxt_username" {
+}
+
+variable "nsxt_password" {
+}
+
+variable "nsxt_hostname" {
+}

--- a/vra/data_source_cloud_account_nsxt.go
+++ b/vra/data_source_cloud_account_nsxt.go
@@ -13,6 +13,13 @@ func dataSourceCloudAccountNSXT() *schema.Resource {
 		Read: dataSourceCloudAccountNSXTRead,
 
 		Schema: map[string]*schema.Schema{
+			"associated_cloud_account_ids": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"dc_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -61,6 +68,7 @@ func dataSourceCloudAccountNSXTRead(d *schema.ResourceData, meta interface{}) er
 
 	setFields := func(account *models.CloudAccountNsxT) error {
 		d.SetId(*account.ID)
+		d.Set("associated_cloud_account_ids", flattenAssociatedCloudAccountIds(account.Links))
 		d.Set("dc_id", account.Dcid)
 		d.Set("description", account.Description)
 		d.Set("hostname", account.HostName)

--- a/vra/data_source_cloud_account_nsxv.go
+++ b/vra/data_source_cloud_account_nsxv.go
@@ -13,6 +13,13 @@ func dataSourceCloudAccountNSXV() *schema.Resource {
 		Read: dataSourceCloudAccountNSXVRead,
 
 		Schema: map[string]*schema.Schema{
+			"associated_cloud_account_ids": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"dc_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -61,6 +68,7 @@ func dataSourceCloudAccountNSXVRead(d *schema.ResourceData, meta interface{}) er
 
 	setFields := func(account *models.CloudAccountNsxV) error {
 		d.SetId(*account.ID)
+		d.Set("associated_cloud_account_ids", flattenAssociatedCloudAccountIds(account.Links))
 		d.Set("dc_id", account.Dcid)
 		d.Set("description", account.Description)
 		d.Set("hostname", account.HostName)

--- a/vra/data_source_cloud_account_vsphere.go
+++ b/vra/data_source_cloud_account_vsphere.go
@@ -18,6 +18,13 @@ func dataSourceCloudAccountVsphere() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"associated_cloud_account_ids": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"created_at": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -89,6 +96,7 @@ func dataSourceCloudAccountVsphereRead(d *schema.ResourceData, meta interface{})
 
 	setFields := func(account *models.CloudAccountVsphere) {
 		d.SetId(*account.ID)
+		d.Set("associated_cloud_account_ids", flattenAssociatedCloudAccountIds(account.Links))
 		d.Set("created_at", account.CreatedAt)
 		d.Set("custom_properties", account.CustomProperties)
 		d.Set("dcid", account.Dcid)

--- a/vra/resource_cloud_account_nsxt.go
+++ b/vra/resource_cloud_account_nsxt.go
@@ -20,6 +20,13 @@ func resourceCloudAccountNSXT() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"associated_cloud_account_ids": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"accept_self_signed_cert": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -97,7 +104,7 @@ func resourceCloudAccountNSXTRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	nsxtAccount := *ret.Payload
-
+	d.Set("associated_cloud_account_ids", flattenAssociatedCloudAccountIds(nsxtAccount.Links))
 	d.Set("dc_id", nsxtAccount.Dcid)
 	d.Set("description", nsxtAccount.Description)
 	d.Set("name", nsxtAccount.Name)

--- a/vra/resource_cloud_account_nsxv.go
+++ b/vra/resource_cloud_account_nsxv.go
@@ -20,6 +20,13 @@ func resourceCloudAccountNSXV() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"associated_cloud_account_ids": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"accept_self_signed_cert": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -97,7 +104,7 @@ func resourceCloudAccountNSXVRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	nsxvAccount := *ret.Payload
-
+	d.Set("associated_cloud_account_ids", flattenAssociatedCloudAccountIds(nsxvAccount.Links))
 	d.Set("dc_id", nsxvAccount.Dcid)
 	d.Set("description", nsxvAccount.Description)
 	d.Set("name", nsxvAccount.Name)

--- a/vra/structure.go
+++ b/vra/structure.go
@@ -109,8 +109,8 @@ func flattenAndNormalizeCLoudAccountAzureRegionIds(regionOrder []string, cloudAc
 	return m, nil
 }
 
-// flattenAndNormalizeCLoudAccountVsphereRegionIds will return region id's in the same order as regionOrder
-func flattenAndNormalizeCLoudAccountVsphereRegionIds(regionOrder []string, cloudAccount *models.CloudAccountVsphere) ([]string, error) {
+// flattenAndNormalizeCloudAccountVsphereRegionIds will return region id's in the same order as regionOrder
+func flattenAndNormalizeCloudAccountVsphereRegionIds(regionOrder []string, cloudAccount *models.CloudAccountVsphere) ([]string, error) {
 	returnOrder := cloudAccount.EnabledRegionIds
 	refStrings := cloudAccount.Links["regions"].Hrefs
 	m := make([]string, len(regionOrder))
@@ -122,6 +122,16 @@ func flattenAndNormalizeCLoudAccountVsphereRegionIds(regionOrder []string, cloud
 		m[i] = strings.TrimPrefix(refStrings[index], "/iaas/api/regions/")
 	}
 	return m, nil
+}
+
+// flattenAssociatedCloudAccountIds will return associated cloud account ids from the Href links in the order received
+func flattenAssociatedCloudAccountIds(links map[string]models.Href) []string {
+	refStrings := links["associated-cloud-accounts"].Hrefs
+	m := make([]string, len(refStrings))
+	for i, r := range refStrings {
+		m[i] = strings.TrimPrefix(r, "/iaas/api/cloud-accounts/")
+	}
+	return m
 }
 
 // flattenAndNormalizeCLoudAccountGcpRegionIds will return region id's in the same order as regionOrder


### PR DESCRIPTION
Allow an existing NSX-T/V cloud account to be associated with a new vSphere
cloud account. Also update the state for vSphere and NSX-T/V cloud account
resources and data sources with associated cloud account ids if there are any.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>