### PR TITLE
Fix 152 - Allow project creation with cpu, memory and storage limits

### DIFF
--- a/examples/project/README.md
+++ b/examples/project/README.md
@@ -8,9 +8,9 @@ There are variables which need to be added to terraform.tfvars. The first are fo
 
 * `url` - The URL for the vRealize Automation (vRA) endpoint
 * `refresh_token` - The refresh token for the vRA account
-* `cloud_account` - The name of the cloud account added in vRA
-* `region` - The region within in the cloud account
-* `zone` - The compute placement zone within a region where machines can be placed
+* `insecure` - `false` for vRA Cloud and `true` for vRA on-prem
+* `zone_name` - The compute placement zone within a region where machines can be placed
+* `project_name` - Project name
 
 To facilitate adding these variables, a sample tfvars file can be copied first:
 ```shell

--- a/examples/project/main.tf
+++ b/examples/project/main.tf
@@ -1,28 +1,27 @@
 provider "vra" {
   url           = var.url
   refresh_token = var.refresh_token
-}
-
-data "vra_cloud_account_aws" "this" {
-  name = var.cloud_account
-}
-
-data "vra_region" "this" {
-  cloud_account_id = data.vra_cloud_account_aws.this.id
-  region           = var.region
+  insecure      = var.insecure
 }
 
 data "vra_zone" "this" {
-  name = var.zone
+  name = var.zone_name
 }
 
 resource "vra_project" "this" {
-  name        = "tf-vra-project"
+  name        = var.project_name
   description = "terraform test project"
 
   zone_assignments {
-    zone_id       = data.vra_zone.this.id
-    priority      = 1
-    max_instances = 2
+    zone_id          = data.vra_zone.this.id
+    priority         = 1
+    max_instances    = 2
+    cpu_limit        = 1024
+    memory_limit_mb  = 8192
+    storage_limit_gb = 65536
   }
+
+  shared_resources = true
+
+  administrators = ["jason@vra.local"]
 }

--- a/examples/project/variables.tf
+++ b/examples/project/variables.tf
@@ -4,12 +4,9 @@ variable "refresh_token" {
 variable "url" {
 }
 
-variable "cloud_account" {
+variable "insecure" {}
+
+variable "zone_name" {
 }
 
-variable "region" {
-}
-
-variable "zone" {
-
-}
+variable "project_name" {}

--- a/vra/data_source_project.go
+++ b/vra/data_source_project.go
@@ -14,20 +14,84 @@ func dataSourceProject() *schema.Resource {
 		Read: dataSourceProjectRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
+			"administrators": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"members": &schema.Schema{
+				Type:     schema.TypeSet,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"description": {
+			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"shared_resources": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+				Optional: true,
+			},
+			"zone_assignments": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cpu_limit": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Optional:    true,
+							Description: "The maximum amount of cpus that can be used by this cloud zone. Default is 0 (unlimited cpu).",
+						},
+						"max_instances": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Optional:    true,
+							Description: "The maximum number of instances that can be provisioned in this cloud zone. Default is 0 (unlimited instances)",
+						},
+						"memory_limit_mb": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Optional:    true,
+							Description: "The maximum amount of memory that can be used by this cloud zone. Default is 0 (unlimited memory).",
+						},
+						"priority": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Optional:    true,
+							Description: "The priority of this zone in the current project. Lower numbers mean higher priority. Default is 0 (highest)",
+						},
+						"storage_limit_gb": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Optional:    true,
+							Description: "Upper limit on storage that can be requested from a cloud zone which is part of this project. Default is 0 (unlimited storage). Supported only for vSphere cloud zones.",
+						},
+						"zone_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The Cloud Zone Id",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -45,8 +109,12 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	setFields := func(project *models.Project) {
 		d.SetId(*project.ID)
+		d.Set("administrators", flattenUserList(project.Administrators))
 		d.Set("description", project.Description)
+		d.Set("members", flattenUserList(project.Members))
 		d.Set("name", project.Name)
+		d.Set("shared_resources", project.SharedResources)
+		d.Set("zone_assignments", flattenZoneAssignment(project.Zones))
 	}
 
 	if idOk {

--- a/vra/resource_project.go
+++ b/vra/resource_project.go
@@ -49,17 +49,35 @@ func resourceProject() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"zone_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"priority": {
-							Type:     schema.TypeInt,
-							Optional: true,
+						"cpu_limit": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The maximum amount of cpus that can be used by this cloud zone. Default is 0 (unlimited cpu).",
 						},
 						"max_instances": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The maximum number of instances that can be provisioned in this cloud zone. Default is 0 (unlimited instances)",
+						},
+						"memory_limit_mb": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The maximum amount of memory that can be used by this cloud zone. Default is 0 (unlimited memory).",
+						},
+						"priority": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The priority of this zone in the current project. Lower numbers mean higher priority. Default is 0 (highest)",
+						},
+						"storage_limit_gb": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Upper limit on storage that can be requested from a cloud zone which is part of this project. Default is 0 (unlimited storage). Supported only for vSphere cloud zones.",
+						},
+						"zone_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The Cloud Zone Id",
 						},
 					},
 				},
@@ -198,8 +216,11 @@ func expandZoneAssignment(configZoneAssignments []interface{}) []*models.ZoneAss
 		configZoneAssignment := configZone.(map[string]interface{})
 
 		za := models.ZoneAssignmentConfig{
+			CPULimit:           int64(configZoneAssignment["cpu_limit"].(int)),
 			MaxNumberInstances: int64(configZoneAssignment["max_instances"].(int)),
+			MemoryLimitMB:      int64(configZoneAssignment["memory_limit_mb"].(int)),
 			Priority:           int32(configZoneAssignment["priority"].(int)),
+			StorageLimitGB:     int64(configZoneAssignment["storage_limit_gb"].(int)),
 			ZoneID:             configZoneAssignment["zone_id"].(string),
 		}
 
@@ -213,9 +234,12 @@ func flattenZoneAssignment(list []*models.ZoneAssignmentConfig) []map[string]int
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, zoneAssignment := range list {
 		l := map[string]interface{}{
-			"max_instances": zoneAssignment.MaxNumberInstances,
-			"priority":      zoneAssignment.Priority,
-			"zone_id":       zoneAssignment.ZoneID,
+			"cpu_limit":        zoneAssignment.CPULimit,
+			"max_instances":    zoneAssignment.MaxNumberInstances,
+			"memory_limit_mb":  zoneAssignment.MemoryLimitMB,
+			"priority":         zoneAssignment.Priority,
+			"storage_limit_gb": zoneAssignment.StorageLimitGB,
+			"zone_id":          zoneAssignment.ZoneID,
 		}
 
 		result = append(result, l)

--- a/vra/resource_project_test.go
+++ b/vra/resource_project_test.go
@@ -105,29 +105,34 @@ resource "vra_cloud_account_aws" "my-cloud-account" {
 }
 
  resource "vra_zone" "my-zone" {
-    name = "my-vra-zone-%d"
+    name 		= "my-vra-zone-%d"
 	description = "description my-vra-zone"
-	region_id = "${data.vra_region.us-east-1-region.id}"
+	region_id 	= "${data.vra_region.us-east-1-region.id}"
+
     tags {
-        key = "mykey"
-        value = "myvalue"
+        key 	= "mykey"
+        value 	= "myvalue"
     }
     tags {
-        key = "foo"
-        value = "bar"
+        key 	= "foo"
+        value	= "bar"
     }
     tags {
-        key = "faz"
-        value = "baz"
+        key 	= "faz"
+        value 	= "baz"
     }
 }
 resource "vra_project" "my-project" {
-	name = "my-project-%d"
+	name 		= "my-project-%d"
 	description = "update test project"
+
 	zone_assignments {
-		zone_id       = vra_zone.my-zone.id
-		priority      = 1
-		max_instances = 2
+		zone_id       	 = vra_zone.my-zone.id
+		priority      	 = 1
+		max_instances 	 = 2
+		cpu_limit	  	 = 1024
+		memory_limit_mb  = 8192
+		storage_limit_gb = 65536
 	  }
  }`, id, secret, rInt, rInt)
 }


### PR DESCRIPTION
vra_project resource now supports cpu, memory and storage limits on individual
zone assignments. Also vra_project data source now pulls the complete state
of the project into state file.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>