### PR TITLE
Fix 187 - Allow project not to share resources

### DIFF
--- a/examples/project/main.tf
+++ b/examples/project/main.tf
@@ -21,7 +21,11 @@ resource "vra_project" "this" {
     storage_limit_gb = 65536
   }
 
-  shared_resources = true
+  shared_resources = false
 
   administrators = ["jason@vra.local"]
+}
+
+data "vra_project" "this" {
+  name = vra_project.this.name
 }

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
-	github.com/vmware/vra-sdk-go v0.2.9
+	github.com/vmware/vra-sdk-go v0.2.10
 )

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/vra-sdk-go v0.2.9 h1:SZmSAODestQ6RAZfFlu03EMf23kAwu1PX2eGUHj7BQI=
-github.com/vmware/vra-sdk-go v0.2.9/go.mod h1:W6OERth9ssa4FgvS98SOVusGgBNWJs+D4Hq/5ueTgIQ=
+github.com/vmware/vra-sdk-go v0.2.10 h1:nw1NSroINtw8lnaGUtTBuvDWEepBjEkTjEukYSqfJxM=
+github.com/vmware/vra-sdk-go v0.2.10/go.mod h1:W6OERth9ssa4FgvS98SOVusGgBNWJs+D4Hq/5ueTgIQ=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=

--- a/vra/resource_project.go
+++ b/vra/resource_project.go
@@ -101,7 +101,7 @@ func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 		Description:                  description,
 		Members:                      members,
 		Name:                         &name,
-		SharedResources:              sharedResources,
+		SharedResources:              withBool(sharedResources),
 		ZoneAssignmentConfigurations: zoneAssignment,
 	}))
 	if err != nil {
@@ -153,7 +153,7 @@ func resourceProjectUpdate(d *schema.ResourceData, m interface{}) error {
 		Description:                  description,
 		Members:                      members,
 		Name:                         &name,
-		SharedResources:              sharedResources,
+		SharedResources:              withBool(sharedResources),
 		ZoneAssignmentConfigurations: zoneAssignment,
 	}))
 	if err != nil {


### PR DESCRIPTION
Update the SDK to latest version and allow the project not to
share resources provisioned thru this project.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>