### PR TITLE
Add functionality to publich a blueprint into Service Broker catalog

### DIFF
--- a/examples/catalog_item/README.md
+++ b/examples/catalog_item/README.md
@@ -1,0 +1,30 @@
+# publish a catalog item from blueprint and request a deployment example
+
+This is an example of how to publish a Cloud Assembly blueprint into Service Broker catalog and create a deployment from catalog in vRealize Automation(vRA).
+
+Before requesting the deployment, a new project, a new blueprint are created. Besides creating the blueprint, it is versioned and released. Also a new blueprint content source and content sharing are created in order to publish the Cloud Assembly blueprint into Service Broker Catalog.
+
+## Getting Started
+
+There are variables which need to be added to terraform.tfvars.
+
+* `url` - The URL for the vRealize Automation (vRA) endpoint
+* `refresh_token` - The refresh token for the vRA account
+* `insecure` - `false` for vRA Cloud and `true` for vRA on-prem
+* `zone_name` - Existing Cloud Zone Name
+* `project_name` - Project Name to create a new project
+* `blueprint_name` - Blueprint name to create a new blueprint
+* `catalog_source_name` - Catalog Source name to create a new content source for Cloud Assembly blueprints
+* `deployment_name` - Deployment Name to request a new deployment
+
+To facilitate adding these variables, a sample tfvars file can be copied first:
+```shell
+cp terraform.tfvars.sample terraform.tfvars
+```
+
+Once the information is added to `terraform.tfvars`, the cloud account can be brought up via:
+
+```shell
+terraform init
+terraform apply
+```

--- a/examples/catalog_item/main.tf
+++ b/examples/catalog_item/main.tf
@@ -1,0 +1,120 @@
+provider "vra" {
+  url           = var.url
+  refresh_token = var.refresh_token
+  insecure      = var.insecure
+}
+
+resource "random_integer" "suffix" {
+  min = 1
+  max = 50000
+}
+
+data "vra_zone" "this" {
+  name = var.zone_name
+}
+
+resource "vra_project" "this" {
+  name = format("%s-%d", var.project_name, random_integer.suffix.result)
+
+  zone_assignments {
+    zone_id          = data.vra_zone.this.id
+    priority         = 1
+    max_instances    = 2
+    cpu_limit        = 1024
+    memory_limit_mb  = 8192
+    storage_limit_gb = 65536
+  }
+}
+
+resource "vra_blueprint" "this" {
+  name        = format("%s-%d", var.blueprint_name, random_integer.suffix.result)
+  description = "Created by vRA terraform provider"
+
+  project_id = vra_project.this.id
+
+  content = <<-EOT
+    formatVersion: 1
+    inputs:
+      image:
+        type: string
+        description: "Image"
+      flavor:
+        type: string
+        description: "Flavor"
+    resources:
+      Machine:
+        type: Cloud.Machine
+        properties:
+          image: $${input.image}
+          flavor: $${input.flavor}
+  EOT
+}
+
+// Example to create a blueprint version and release it
+resource "vra_blueprint_version" "this" {
+  blueprint_id = vra_blueprint.this.id
+  description  = "Released from vRA terraform provider"
+  version      = (random_integer.suffix.result / random_integer.suffix.result)
+  release      = true
+  change_log   = "First version"
+}
+
+// Example to fetch a blueprint version and release it
+data "vra_blueprint_version" "this" {
+  blueprint_id = vra_blueprint.this.id
+  id           = vra_blueprint_version.this.id
+}
+
+// Example to create a blueprint content source for a project in Service Broker
+resource "vra_catalog_source_blueprint" "this" {
+  depends_on = [vra_blueprint_version.this]
+  name       = format("%s-%d", var.catalog_source_name, random_integer.suffix.result)
+  project_id = vra_project.this.id
+}
+
+// Example to fetch a blueprint catalog soruce id by project_id
+data "vra_catalog_source_blueprint" "this" {
+  depends_on = [vra_catalog_source_blueprint.this]
+  project_id = vra_catalog_source_blueprint.this.project_id
+}
+
+// Example to create a content sharing for a blueprint content source
+resource "vra_catalog_source_entitlement" "this" {
+  depends_on        = [vra_catalog_source_blueprint.this]
+  catalog_source_id = vra_catalog_source_blueprint.this.id
+  project_id        = vra_project.this.id
+}
+
+// Example to fetch a content sharing/entitlement by catalog_source_id and project_id
+data "vra_catalog_source_entitlement" "this" {
+  catalog_source_id = vra_catalog_source_entitlement.this.catalog_source_id
+  project_id        = vra_project.this.id
+}
+
+// Example fetch catalog item
+data "vra_catalog_item" "this" {
+  depends_on      = [vra_catalog_source_blueprint.this, vra_catalog_source_entitlement.this]
+  name            = vra_blueprint.this.name
+  expand_versions = true
+}
+
+// Example to request a deployment from a catalog item
+resource "vra_deployment" "this" {
+  name        = format("%s-%d", var.deployment_name, random_integer.suffix.result)
+  description = "terraform test deployment"
+
+  catalog_item_id      = data.vra_catalog_item.this.id
+  catalog_item_version = vra_blueprint_version.this.version
+  project_id           = vra_project.this.id
+
+  inputs = {
+    flavor = "small"
+    image  = "centos"
+  }
+
+  timeouts {
+    create = "30m"
+    delete = "30m"
+    update = "30m"
+  }
+}

--- a/examples/catalog_item/variables.tf
+++ b/examples/catalog_item/variables.tf
@@ -1,0 +1,15 @@
+variable "url" {}
+
+variable "refresh_token" {}
+
+variable "insecure" {}
+
+variable "zone_name" {}
+
+variable "project_name" {}
+
+variable "blueprint_name" {}
+
+variable "catalog_source_name" {}
+
+variable "deployment_name" {}

--- a/vra/data_source_blueprint_version.go
+++ b/vra/data_source_blueprint_version.go
@@ -1,0 +1,131 @@
+package vra
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/client/blueprint"
+)
+
+func dataSourceBlueprintVersion() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceBlueprintVersionRead,
+
+		Schema: map[string]*schema.Schema{
+			"blueprint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"blueprint_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"valid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version_change_log": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceBlueprintVersionRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Reading the vra_blueprint_version data source")
+	apiClient := m.(*Client).apiClient
+
+	id := d.Get("id").(string)
+	bpUUID := strfmt.UUID(d.Get("blueprint_id").(string))
+
+	resp, err := apiClient.Blueprint.GetBlueprintVersionUsingGET1(
+		blueprint.NewGetBlueprintVersionUsingGET1Params().
+			WithBlueprintID(bpUUID).
+			WithVersion(id).
+			WithDollarSelect([]string{"*"}))
+
+	if err != nil {
+		switch err.(type) {
+		case *blueprint.GetBlueprintVersionUsingGET1NotFound:
+			return fmt.Errorf("blueprint version '%v' is not found", id)
+		}
+		return err
+	}
+
+	blueprintVersion := *resp.Payload
+	d.SetId(blueprintVersion.ID)
+	d.Set("blueprint_id", blueprintVersion.BlueprintID)
+	d.Set("blueprint_description", blueprintVersion.Description)
+	d.Set("change_log", blueprintVersion.VersionChangeLog)
+	d.Set("content", blueprintVersion.Content)
+	d.Set("created_at", blueprintVersion.CreatedAt)
+	d.Set("created_by", blueprintVersion.CreatedBy)
+	d.Set("description", blueprintVersion.VersionDescription)
+	d.Set("name", blueprintVersion.Name)
+	d.Set("org_id", blueprintVersion.OrgID)
+	d.Set("project_id", blueprintVersion.ProjectID)
+	d.Set("project_name", blueprintVersion.ProjectName)
+	d.Set("status", blueprintVersion.Status)
+	d.Set("updated_at", blueprintVersion.UpdatedAt)
+	d.Set("updated_by", blueprintVersion.UpdatedBy)
+	d.Set("valid", blueprintVersion.Valid)
+	d.Set("version", blueprintVersion.Version)
+
+	log.Printf("finished reading vra_blueprint_version data source '%v'", id)
+	return nil
+}

--- a/vra/data_source_blueprint_version_test.go
+++ b/vra/data_source_blueprint_version_test.go
@@ -1,0 +1,82 @@
+package vra
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+	"testing"
+)
+
+func TestAccDataSourceVRABlueprintVersion_Valid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_blueprint_version.this"
+	dataSource := "data.vra_blueprint_version.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckBlueprint(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRABlueprintVersionFoundConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resource1, "blueprint_id", dataSource, "blueprint_id"),
+					resource.TestCheckResourceAttrPair(resource1, "id", dataSource, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "description", dataSource, "description"),
+					resource.TestCheckResourceAttrPair(resource1, "blueprint_description", dataSource, "blueprint_description"),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", dataSource, "project_id"),
+					resource.TestCheckResourceAttrPair(resource1, "project_name", dataSource, "project_name"),
+				),
+			},
+			{
+				Config:      testAccCheckVRABlueprintVersionNotFoundConfig(rInt),
+				ExpectError: regexp.MustCompile("blueprint version '10' is not found"),
+			},
+		},
+	})
+}
+
+func testAccCheckVRABlueprintVersionFoundConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "vra_project" "this" {
+	  name = "terraform-test-project-%d"
+	}
+
+	resource "vra_blueprint" "this" {
+	  name        = "test-blueprint-%d"
+	  description = "terraform test blueprint"
+
+	  project_id = vra_project.this.id
+
+	  content = <<-EOT
+				 formatVersion: 1
+				 inputs: {}
+				 resources:  {}
+				EOT
+	}
+
+   resource "vra_blueprint_version" "this" {
+	  blueprint_id = vra_blueprint.this.id
+     description  = "Released from vRA terraform provider"
+     version      = 1
+     release      = true
+     change_log   = "First version"
+
+   }
+
+	data "vra_blueprint_version" "this" {
+ 	  blueprint_id = vra_blueprint.this.id
+ 	  id           = vra_blueprint_version.this.id
+	}`, rInt, rInt)
+}
+
+func testAccCheckVRABlueprintVersionNotFoundConfig(rInt int) string {
+	return testAccCheckVRABlueprintVersionFoundConfig(rInt) + `
+	data "vra_blueprint_version" "invalid" {
+  	  blueprint_id = vra_blueprint.this.id
+  	  id           = 10
+	}`
+}

--- a/vra/data_source_catalog_source_blueprint.go
+++ b/vra/data_source_catalog_source_blueprint.go
@@ -1,0 +1,187 @@
+package vra
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/vmware/vra-sdk-go/pkg/client/catalog_sources"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceCatalogSourceBlueprint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCatalogSourceBlueprintRead,
+
+		Schema: map[string]*schema.Schema{
+			"config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"created_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"global": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"items_found": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"items_imported": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_import_completed_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_import_errors": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"last_import_started_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_updated_by": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCatalogSourceBlueprintRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Looking up the vra_catalog_source_blueprint data resource with name")
+	apiClient := m.(*Client).apiClient
+
+	id, idOk := d.GetOk("id")
+	name, nameOk := d.GetOk("name")
+	projectID, projectIDOk := d.GetOk("project_id")
+
+	if !idOk && !nameOk && !projectIDOk {
+		return fmt.Errorf("one of id or name or project_id must be provided")
+	}
+
+	setFields := func(catalogSource *models.CatalogSource) {
+		d.SetId(catalogSource.ID.String())
+
+		d.Set("config", expandCatalogSourceConfig(catalogSource.Config))
+		d.Set("created_at", catalogSource.CreatedAt)
+		d.Set("created_by", catalogSource.CreatedBy)
+		d.Set("description", catalogSource.Description)
+		d.Set("global", catalogSource.Global)
+		d.Set("items_found", catalogSource.ItemsFound)
+		d.Set("items_imported", catalogSource.ItemsImported)
+		d.Set("last_import_completed_at", catalogSource.LastImportCompletedAt)
+		d.Set("last_import_errors", catalogSource.LastImportErrors)
+		d.Set("last_import_started_at", catalogSource.LastImportStartedAt)
+		d.Set("last_updated_at", catalogSource.LastUpdatedAt)
+		d.Set("last_updated_by", catalogSource.LastUpdatedBy)
+		d.Set("name", catalogSource.Name)
+		d.Set("project_id", catalogSource.ProjectID)
+		d.Set("type_id", catalogSource.TypeID)
+	}
+
+	// Get catalog source by id if id is provided
+	if idOk {
+		resp, err := apiClient.CatalogSources.GetUsingGET(
+			catalog_sources.NewGetUsingGETParams().WithSourceID(strfmt.UUID(id.(string))))
+
+		if err != nil {
+			switch err.(type) {
+			case *catalog_sources.GetUsingGETNotFound:
+				return fmt.Errorf("blueprint catalog source with id '%v' is not found", id)
+			}
+			return err
+		}
+
+		setFields(resp.Payload)
+		log.Printf("Finished reading the vra_catalog_source_blueprint resource with id  '%v'", id)
+		return nil
+	}
+
+	// Search catalog sources if name is provided and look for exact match with type com.vmw.blueprint
+	if nameOk {
+		resp, err := apiClient.CatalogSources.GetPageUsingGET(
+			catalog_sources.NewGetPageUsingGETParams().WithSearch(withString(name.(string))))
+
+		if err != nil {
+			return err
+		}
+
+		if resp.Payload.NumberOfElements > 0 {
+			for _, catalogSource := range resp.Payload.Content {
+				if *catalogSource.Name == name.(string) && *catalogSource.TypeID == "com.vmw.blueprint" {
+					setFields(catalogSource)
+					log.Printf("Finished reading the vra_catalog_source_blueprint resource with name  '%v'", name)
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("blueprint catalog source with name '%v' is not found", name)
+	}
+
+	// Filter catalog sources if projectId is provided and look for exact match with type com.vmw.blueprint and projectId as global catalog sources are returned as well
+	if projectIDOk {
+		resp, err := apiClient.CatalogSources.GetPageUsingGET(
+			catalog_sources.NewGetPageUsingGETParams().WithProjectID(withString(projectID.(string))))
+
+		if err != nil {
+			return err
+		}
+
+		if resp.Payload.NumberOfElements > 0 {
+			for _, catalogSource := range resp.Payload.Content {
+				if catalogSource.ProjectID == projectID.(string) && *catalogSource.TypeID == "com.vmw.blueprint" {
+					setFields(catalogSource)
+					log.Printf("Finished reading the vra_catalog_source_blueprint resource with project_id '%v'", projectID)
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("blueprint catalog source with project_id '%v' is not found", projectID)
+	}
+
+	return nil
+}

--- a/vra/data_source_catalog_source_blueprint_test.go
+++ b/vra/data_source_catalog_source_blueprint_test.go
@@ -1,0 +1,103 @@
+package vra
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+	"testing"
+)
+
+func TestAccDataSourceVRACatalogSourceBlueprint_Valid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_catalog_source_blueprint.this"
+	dataSourceWithProjectID := "data.vra_catalog_source_blueprint.with_project_id"
+	dataSourceWithID := "data.vra_catalog_source_blueprint.with_id"
+	dataSourceWithName := "data.vra_catalog_source_blueprint.with_name"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckBlueprint(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRACatalogSourceBlueprintFoundConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resource1, "project_id", dataSourceWithProjectID, "project_id"),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", dataSourceWithProjectID, "config.sourceProjectId"),
+					resource.TestCheckResourceAttrPair(resource1, "id", dataSourceWithProjectID, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "name", dataSourceWithProjectID, "name"),
+					resource.TestCheckResourceAttrPair(resource1, "type_id", dataSourceWithProjectID, "type_id"),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", dataSourceWithID, "project_id"),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", dataSourceWithID, "config.sourceProjectId"),
+					resource.TestCheckResourceAttrPair(resource1, "id", dataSourceWithID, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "name", dataSourceWithID, "name"),
+					resource.TestCheckResourceAttrPair(resource1, "type_id", dataSourceWithID, "type_id"),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", dataSourceWithName, "project_id"),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", dataSourceWithName, "config.sourceProjectId"),
+					resource.TestCheckResourceAttrPair(resource1, "id", dataSourceWithName, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "name", dataSourceWithName, "name"),
+					resource.TestCheckResourceAttrPair(resource1, "type_id", dataSourceWithName, "type_id"),
+				),
+			},
+			{
+				Config:      testAccCheckVRACatalogSourceBlueprintByIDNotFoundConfig(),
+				ExpectError: regexp.MustCompile("blueprint catalog source with id '22b52754-09d5-4706-b42e-fe487da520f3' is not found"),
+			},
+			{
+				Config:      testAccCheckVRACatalogSourceBlueprintByProjectIDNotFoundConfig(),
+				ExpectError: regexp.MustCompile("blueprint catalog source with project_id 'invalid-id' is not found"),
+			},
+			{
+				Config:      testAccCheckVRACatalogSourceBlueprintByNameNotFoundConfig(),
+				ExpectError: regexp.MustCompile("blueprint catalog source with name 'invalid-name' is not found"),
+			},
+		},
+	})
+}
+
+func testAccCheckVRACatalogSourceBlueprintFoundConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "vra_project" "this" {
+	  name = "terraform-test-project-%d"
+	}
+
+	resource "vra_catalog_source_blueprint" "this" {
+	  name       = "tf-test-catalog-source-%d"
+  	  project_id = vra_project.this.id
+	}
+
+	data "vra_catalog_source_blueprint" "with_project_id" {
+ 	  project_id = vra_catalog_source_blueprint.this.project_id
+	}
+
+	data "vra_catalog_source_blueprint" "with_id" {
+ 	  id = vra_catalog_source_blueprint.this.id
+	}
+
+	data "vra_catalog_source_blueprint" "with_name" {
+ 	  name = vra_catalog_source_blueprint.this.name
+	}`, rInt, rInt)
+}
+
+func testAccCheckVRACatalogSourceBlueprintByIDNotFoundConfig() string {
+	return `
+	data "vra_catalog_source_blueprint" "invalid_id" {
+ 	  id = "22b52754-09d5-4706-b42e-fe487da520f3"
+	}`
+}
+
+func testAccCheckVRACatalogSourceBlueprintByProjectIDNotFoundConfig() string {
+	return `
+	data "vra_catalog_source_blueprint" "invalid_project_id" {
+ 	  project_id = "invalid-id"
+	}`
+}
+
+func testAccCheckVRACatalogSourceBlueprintByNameNotFoundConfig() string {
+	return `
+	data "vra_catalog_source_blueprint" "invalid_name" {
+ 	  name = "invalid-name"
+	}`
+}

--- a/vra/data_source_catalog_source_entitlement.go
+++ b/vra/data_source_catalog_source_entitlement.go
@@ -1,0 +1,113 @@
+package vra
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/client/catalog_entitlements"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+)
+
+func dataSourceCatalogSourceEntitlement() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCatalogSourceEntitlementRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"catalog_source_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"definition": &schema.Schema{
+				Type:     schema.TypeSet,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"number_of_items": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"source_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceCatalogSourceEntitlementRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Reading the vra_catalog_source_entitlement data source")
+	apiClient := m.(*Client).apiClient
+
+	id, idOk := d.GetOk("id")
+	catalogSourceID, catalogSourceIDOk := d.GetOk("catalog_source_id")
+	projectID := d.Get("project_id").(string)
+
+	if !idOk && !catalogSourceIDOk {
+		return fmt.Errorf("one of id or catalog_source_id must be provided with project_id")
+	}
+
+	resp, err := apiClient.CatalogEntitlements.GetEntitlementsUsingGET(
+		catalog_entitlements.NewGetEntitlementsUsingGETParams().WithProjectID(withString(projectID)))
+
+	if err != nil {
+		return err
+	}
+
+	setFields := func(entitlement *models.Entitlement) {
+		d.SetId(entitlement.ID.String())
+		d.Set("project_id", entitlement.ProjectID)
+		d.Set("catalog_source_id", entitlement.Definition.ID)
+		d.Set("definition", flattenContentDefinition(entitlement.Definition))
+	}
+
+	if len(resp.Payload) > 0 {
+		for _, entitlement := range resp.Payload {
+			if idOk && entitlement.ID.String() == id.(string) {
+				setFields(entitlement)
+				log.Printf("Finished reading the vra_catalog_source_entitlement data source")
+				return nil
+			}
+
+			if catalogSourceIDOk && entitlement.Definition.ID.String() == catalogSourceID.(string) {
+				setFields(entitlement)
+				log.Printf("Finished reading the vra_catalog_source_entitlement data source")
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("no catalog source entitlements found for the project_id '%v'", projectID)
+
+}

--- a/vra/data_source_catalog_source_entitlement_test.go
+++ b/vra/data_source_catalog_source_entitlement_test.go
@@ -1,0 +1,67 @@
+package vra
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceVRACatalogSourceEntitlement_Valid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_catalog_source_entitlement.this"
+	dataSource1 := "data.vra_catalog_source_entitlement.with_id"
+	dataSource2 := "data.vra_catalog_source_entitlement.with_catalog_source_id"
+	catalogSource := "vra_catalog_source_blueprint.this"
+	project := "vra_project.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckBlueprint(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRACatalogSourceEntitlementFoundConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resource1, "id", dataSource1, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "definition.0.id", dataSource1, "definition.0.id"),
+					resource.TestCheckResourceAttrPair(catalogSource, "id", dataSource1, "definition.0.id"),
+					resource.TestCheckResourceAttrPair(catalogSource, "name", dataSource1, "definition.0.name"),
+					resource.TestCheckResourceAttrPair(project, "id", dataSource1, "project_id"),
+					resource.TestCheckResourceAttrPair(resource1, "id", dataSource2, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "definition.0.id", dataSource2, "definition.0.id"),
+					resource.TestCheckResourceAttrPair(catalogSource, "id", dataSource2, "definition.0.id"),
+					resource.TestCheckResourceAttrPair(catalogSource, "name", dataSource2, "definition.0.name"),
+					resource.TestCheckResourceAttrPair(project, "id", dataSource2, "project_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVRACatalogSourceEntitlementFoundConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "vra_project" "this" {
+	  name = "tf-test-project-%d"
+	}
+
+	resource "vra_catalog_source_blueprint" "this" {
+ 	  name       = "tf-test-catalog-source-%d"
+  	  project_id = vra_project.this.id
+	}
+
+	resource "vra_catalog_source_entitlement" "this" {
+  	  catalog_source_id = vra_catalog_source_blueprint.this.id
+	  project_id        = vra_project.this.id
+	}
+
+	data "vra_catalog_source_entitlement" "with_id" {
+ 	  id = vra_catalog_source_entitlement.this.id
+	  project_id = vra_catalog_source_entitlement.this.project_id
+	}
+
+	data "vra_catalog_source_entitlement" "with_catalog_source_id" {
+ 	  catalog_source_id = vra_catalog_source_entitlement.this.catalog_source_id
+	  project_id = vra_catalog_source_entitlement.this.project_id
+	}`, rInt, rInt)
+}

--- a/vra/provider.go
+++ b/vra/provider.go
@@ -47,7 +47,10 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"vra_block_device":               dataSourceBlockDevice(),
 			"vra_blueprint":                  dataSourceBlueprint(),
+			"vra_blueprint_version":          dataSourceBlueprintVersion(),
 			"vra_catalog_item":               dataSourceCatalogItem(),
+			"vra_catalog_source_blueprint":   dataSourceCatalogSourceBlueprint(),
+			"vra_catalog_source_entitlement": dataSourceCatalogSourceEntitlement(),
 			"vra_cloud_account_aws":          dataSourceCloudAccountAWS(),
 			"vra_cloud_account_azure":        dataSourceCloudAccountAzure(),
 			"vra_cloud_account_gcp":          dataSourceCloudAccountGCP(),
@@ -77,28 +80,31 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"vra_block_device":          resourceBlockDevice(),
-			"vra_blueprint":             resourceBlueprint(),
-			"vra_cloud_account_aws":     resourceCloudAccountAWS(),
-			"vra_cloud_account_azure":   resourceCloudAccountAzure(),
-			"vra_cloud_account_gcp":     resourceCloudAccountGCP(),
-			"vra_cloud_account_nsxt":    resourceCloudAccountNSXT(),
-			"vra_cloud_account_nsxv":    resourceCloudAccountNSXV(),
-			"vra_cloud_account_vmc":     resourceCloudAccountVMC(),
-			"vra_cloud_account_vsphere": resourceCloudAccountVsphere(),
-			"vra_content_source":        resourceContentSource(),
-			"vra_deployment":            resourceDeployment(),
-			"vra_flavor_profile":        resourceFlavorProfile(),
-			"vra_image_profile":         resourceImageProfile(),
-			"vra_load_balancer":         resourceLoadBalancer(),
-			"vra_machine":               resourceMachine(),
-			"vra_network":               resourceNetwork(),
-			"vra_network_profile":       resourceNetworkProfile(),
-			"vra_project":               resourceProject(),
-			"vra_storage_profile":       resourceStorageProfile(),
-			"vra_storage_profile_aws":   resourceStorageProfileAws(),
-			"vra_storage_profile_azure": resourceStorageProfileAzure(),
-			"vra_zone":                  resourceZone(),
+			"vra_block_device":               resourceBlockDevice(),
+			"vra_blueprint":                  resourceBlueprint(),
+			"vra_blueprint_version":          resourceBlueprintVersion(),
+			"vra_catalog_source_blueprint":   resourceCatalogSourceBlueprint(),
+			"vra_catalog_source_entitlement": resourceCatalogSourceEntitlement(),
+			"vra_cloud_account_aws":          resourceCloudAccountAWS(),
+			"vra_cloud_account_azure":        resourceCloudAccountAzure(),
+			"vra_cloud_account_gcp":          resourceCloudAccountGCP(),
+			"vra_cloud_account_nsxt":         resourceCloudAccountNSXT(),
+			"vra_cloud_account_nsxv":         resourceCloudAccountNSXV(),
+			"vra_cloud_account_vmc":          resourceCloudAccountVMC(),
+			"vra_cloud_account_vsphere":      resourceCloudAccountVsphere(),
+			"vra_content_source":             resourceContentSource(),
+			"vra_deployment":                 resourceDeployment(),
+			"vra_flavor_profile":             resourceFlavorProfile(),
+			"vra_image_profile":              resourceImageProfile(),
+			"vra_load_balancer":              resourceLoadBalancer(),
+			"vra_machine":                    resourceMachine(),
+			"vra_network":                    resourceNetwork(),
+			"vra_network_profile":            resourceNetworkProfile(),
+			"vra_project":                    resourceProject(),
+			"vra_storage_profile":            resourceStorageProfile(),
+			"vra_storage_profile_aws":        resourceStorageProfileAws(),
+			"vra_storage_profile_azure":      resourceStorageProfileAzure(),
+			"vra_zone":                       resourceZone(),
 		},
 
 		ConfigureFunc: configureProvider,
@@ -109,6 +115,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	url := d.Get("url").(string)
 	refreshToken := ""
 	accessToken := ""
+	reauth := "0"
 
 	if v, ok := d.GetOk("refresh_token"); ok {
 		refreshToken = v.(string)
@@ -119,7 +126,10 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	insecure := d.Get("insecure").(bool)
-	reauth := d.Get("reauthorize_timeout").(string)
+
+	if v, ok := d.GetOk("reauthorize_timeout"); ok {
+		reauth = v.(string)
+	}
 
 	if accessToken == "" && refreshToken == "" {
 		return nil, errors.New("refresh_token or access_token required")

--- a/vra/resource_blueprint_test.go
+++ b/vra/resource_blueprint_test.go
@@ -28,7 +28,6 @@ func TestAccVRABlueprint_Valid(t *testing.T) {
 			{
 				Config: testAccCheckVRABlueprintValidContentConfig(rInt),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckVRADeploymentExists(resource1),
 					resource.TestMatchResourceAttr(resource1, "name", regexp.MustCompile("^test-blueprint-"+strconv.Itoa(rInt))),
 					resource.TestCheckResourceAttrPair(resource1, "project_id", project, "id"),
 					resource.TestCheckResourceAttr(resource1, "description", "terraform test blueprint"),

--- a/vra/resource_blueprint_version.go
+++ b/vra/resource_blueprint_version.go
@@ -1,0 +1,209 @@
+package vra
+
+import (
+	"github.com/vmware/vra-sdk-go/pkg/client/blueprint"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"log"
+)
+
+func resourceBlueprintVersion() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBlueprintVersionCreate,
+		Read:   resourceBlueprintVersionRead,
+		Update: resourceBlueprintVersionUpdate,
+		Delete: resourceBlueprintVersionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"blueprint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"blueprint_description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"change_log": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"release": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"valid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceBlueprintVersionCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to create vra_blueprint_version resource")
+	apiClient := m.(*Client).apiClient
+
+	blueprintVersionRequestSpecification := models.BlueprintVersionRequest{
+		ChangeLog: d.Get("change_log").(string),
+		Release:   d.Get("release").(bool),
+		Version:   withString(d.Get("version").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		blueprintVersionRequestSpecification.Description = v.(string)
+	}
+
+	resp, err := apiClient.Blueprint.CreateBlueprintVersionUsingPOST1(
+		blueprint.NewCreateBlueprintVersionUsingPOST1Params().
+			WithBlueprintID(strfmt.UUID(d.Get("blueprint_id").(string))).
+			WithVersionRequest(&blueprintVersionRequestSpecification))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resp.GetPayload().ID)
+	log.Printf("Finished to create vra_blueprint_version resource with blueprint_id %s version %s", d.Get("blueprint_id"), d.Get("version"))
+
+	return resourceBlueprintVersionRead(d, m)
+}
+
+func resourceBlueprintVersionRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Reading the vra_blueprint_version resource with blueprint_id %s and version %s", d.Get("blueprint_id"), d.Get("version"))
+	apiClient := m.(*Client).apiClient
+
+	id := d.Id()
+	bpUUID := strfmt.UUID(d.Get("blueprint_id").(string))
+
+	resp, err := apiClient.Blueprint.GetBlueprintVersionUsingGET1(
+		blueprint.NewGetBlueprintVersionUsingGET1Params().
+			WithBlueprintID(bpUUID).
+			WithVersion(id).
+			WithDollarSelect([]string{"*"}))
+
+	if err != nil {
+		switch err.(type) {
+		case *blueprint.GetBlueprintVersionUsingGET1NotFound:
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	blueprintVersion := *resp.Payload
+	d.SetId(blueprintVersion.ID)
+	d.Set("blueprint_id", blueprintVersion.BlueprintID)
+	d.Set("blueprint_description", blueprintVersion.Description)
+	d.Set("change_log", blueprintVersion.VersionChangeLog)
+	d.Set("content", blueprintVersion.Content)
+	d.Set("created_at", blueprintVersion.CreatedAt)
+	d.Set("created_by", blueprintVersion.CreatedBy)
+	d.Set("description", blueprintVersion.VersionDescription)
+	d.Set("name", blueprintVersion.Name)
+	d.Set("org_id", blueprintVersion.OrgID)
+	d.Set("project_id", blueprintVersion.ProjectID)
+	d.Set("project_name", blueprintVersion.ProjectName)
+	d.Set("status", blueprintVersion.Status)
+	d.Set("updated_at", blueprintVersion.UpdatedAt)
+	d.Set("updated_by", blueprintVersion.UpdatedBy)
+	d.Set("valid", blueprintVersion.Valid)
+	d.Set("version", blueprintVersion.Version)
+
+	log.Printf("Finished reading the vra_blueprint_version resource with blueprint_id %s and version %s", d.Get("blueprint_id"), d.Get("version"))
+	return nil
+}
+
+func resourceBlueprintVersionUpdate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to update the vra_blueprint_version resource with blueprint_id %s and version %s", d.Get("blueprint_id"), d.Get("version"))
+	apiClient := m.(*Client).apiClient
+
+	if d.HasChange("release") {
+		bpUUID := strfmt.UUID(d.Get("blueprint_id").(string))
+		version := d.Get("version").(string)
+		if d.Get("release").(bool) {
+			_, err := apiClient.Blueprint.ReleaseBlueprintVersionUsingPOST1(
+				blueprint.NewReleaseBlueprintVersionUsingPOST1Params().
+					WithBlueprintID(bpUUID).
+					WithVersion(version))
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err := apiClient.Blueprint.UnReleaseBlueprintVersionUsingPOST1(
+				blueprint.NewUnReleaseBlueprintVersionUsingPOST1Params().
+					WithBlueprintID(bpUUID).
+					WithVersion(version))
+			if err != nil {
+				return err
+			}
+		}
+		log.Printf("Finished updating the vra_blueprint resource with name %s", d.Get("name"))
+	} else {
+		log.Printf("only changes supported on vra_blueprint_version resource are to release flag")
+	}
+
+	return resourceBlueprintVersionRead(d, m)
+}
+
+func resourceBlueprintVersionDelete(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to delete the vra_blueprint_version resource with blueprint_id %s and version %s", d.Get("blueprint_id"), d.Get("version"))
+	log.Printf("vra_blueprint_version cannot be deleted in vRA. It can only  be unreleased. Removing local state")
+	d.SetId("")
+	log.Printf("Finished deleting the vra_blueprint resource with name %s", d.Get("name"))
+	return nil
+}

--- a/vra/resource_blueprint_version_test.go
+++ b/vra/resource_blueprint_version_test.go
@@ -1,0 +1,89 @@
+package vra
+
+import (
+	"fmt"
+
+	"github.com/vmware/vra-sdk-go/pkg/client/blueprint"
+
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccVRABlueprintVersion_Valid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_blueprint_version.this"
+	blueprint := "vra_blueprint.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBlueprint(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRABlueprintVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRABlueprintVersionValidContentConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(resource1, "name", regexp.MustCompile("^test-blueprint-"+strconv.Itoa(rInt))),
+					resource.TestCheckResourceAttrPair(resource1, "blueprint_id", blueprint, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "name", blueprint, "name"),
+					resource.TestCheckResourceAttrPair(resource1, "blueprint_description", blueprint, "description"),
+					resource.TestCheckResourceAttrPair(resource1, "id", resource1, "version"),
+					resource.TestCheckResourceAttr(resource1, "description", "Released from vRA terraform provider"),
+					resource.TestCheckResourceAttr(resource1, "change_log", "First version"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVRABlueprintVersionDestroy(s *terraform.State) error {
+	apiClient := testAccProviderVRA.Meta().(*Client).apiClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vra_blueprint" {
+			continue
+		}
+
+		_, err := apiClient.Blueprint.GetBlueprintUsingGET1(blueprint.NewGetBlueprintUsingGET1Params().WithBlueprintID(strfmt.UUID(rs.Primary.ID)))
+		if err == nil {
+			return fmt.Errorf("resource 'vra_blueprint' still exists with id %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVRABlueprintVersionValidContentConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "vra_project" "this" {
+	  name = "terraform-test-project"
+	}
+
+	resource "vra_blueprint" "this" {
+	  name        = "test-blueprint-%d"
+	  description = "terraform test blueprint"
+
+	  project_id = vra_project.this.id
+
+	  content = <<-EOT
+				 formatVersion: 1
+				 inputs: {}
+				 resources:  {}
+				EOT
+	}
+
+    resource "vra_blueprint_version" "this" {
+	  blueprint_id = vra_blueprint.this.id
+      description  = "Released from vRA terraform provider"
+      version      = 1
+      release      = true
+      change_log   = "First version"
+
+    }`, rInt)
+}

--- a/vra/resource_catalog_source_blueprint.go
+++ b/vra/resource_catalog_source_blueprint.go
@@ -1,0 +1,211 @@
+package vra
+
+import (
+	"github.com/vmware/vra-sdk-go/pkg/client/catalog_sources"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"log"
+)
+
+func resourceCatalogSourceBlueprint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCatalogSourceBlueprintCreate,
+		Delete: resourceCatalogSourceBlueprintDelete,
+		Read:   resourceCatalogSourceBlueprintRead,
+		Update: resourceCatalogSourceBlueprintUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"created_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"global": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"items_found": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"items_imported": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_import_completed_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_import_errors": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"last_import_started_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_updated_by": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCatalogSourceBlueprintCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("starting to create vra_catalog_source_blueprint resource")
+
+	apiClient := m.(*Client).apiClient
+
+	name := d.Get("name").(string)
+
+	config := make(map[string]interface{})
+	config["sourceProjectId"] = d.Get("project_id").(string)
+
+	catalogSource := models.CatalogSource{
+		Config: config,
+		Name:   withString(name),
+		TypeID: withString("com.vmw.blueprint"),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		catalogSource.Description = v.(string)
+	}
+
+	_, createResp, err := apiClient.CatalogSources.PostUsingPOST(
+		catalog_sources.NewPostUsingPOSTParams().WithSource(&catalogSource))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(createResp.GetPayload().ID.String())
+	log.Printf("Finished creating vra_catalog_source_blueprint resource with name %s", d.Get("name"))
+
+	return resourceCatalogSourceBlueprintRead(d, m)
+}
+
+func resourceCatalogSourceBlueprintRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Reading the vra_catalog_source_blueprint resource with name %s", d.Get("name"))
+	apiClient := m.(*Client).apiClient
+
+	resp, err := apiClient.CatalogSources.GetUsingGET(
+		catalog_sources.NewGetUsingGETParams().WithSourceID(strfmt.UUID(d.Id())))
+
+	if err != nil {
+		switch err.(type) {
+		case *catalog_sources.GetUsingGETNotFound:
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	catalogSource := *resp.Payload
+	d.Set("config", expandCatalogSourceConfig(catalogSource.Config))
+	d.Set("created_at", catalogSource.CreatedAt)
+	d.Set("created_by", catalogSource.CreatedBy)
+	d.Set("description", catalogSource.Description)
+	d.Set("global", catalogSource.Global)
+	d.Set("items_found", catalogSource.ItemsFound)
+	d.Set("items_imported", catalogSource.ItemsImported)
+	d.Set("last_import_completed_at", catalogSource.LastImportCompletedAt)
+	d.Set("last_import_errors", catalogSource.LastImportErrors)
+	d.Set("last_import_started_at", catalogSource.LastImportStartedAt)
+	d.Set("last_updated_at", catalogSource.LastUpdatedAt)
+	d.Set("last_updated_by", catalogSource.LastUpdatedBy)
+	d.Set("name", catalogSource.Name)
+	d.Set("project_id", catalogSource.ProjectID)
+	d.Set("type_id", catalogSource.TypeID)
+
+	log.Printf("Finished reading the vra_catalog_source_blueprint resource with name %s", d.Get("name"))
+	return nil
+}
+
+func resourceCatalogSourceBlueprintUpdate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("starting to update vra_catalog_source_blueprint resource")
+
+	apiClient := m.(*Client).apiClient
+
+	name := d.Get("name").(string)
+
+	config := make(map[string]interface{})
+	config["sourceProjectId"] = d.Get("project_id").(string)
+
+	csID := strfmt.UUID(d.Id())
+
+	catalogSource := models.CatalogSource{
+		Config: config,
+		ID:     &csID,
+		Name:   withString(name),
+		TypeID: withString("com.vmw.blueprint"),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		catalogSource.Description = v.(string)
+	}
+
+	_, createResp, err := apiClient.CatalogSources.PostUsingPOST(
+		catalog_sources.NewPostUsingPOSTParams().WithSource(&catalogSource))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(createResp.GetPayload().ID.String())
+	log.Printf("Finished updating vra_catalog_source_blueprint resource with name %s", d.Get("name"))
+
+	return resourceCatalogSourceBlueprintRead(d, m)
+}
+
+func resourceCatalogSourceBlueprintDelete(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to delete the vra_catalog_source_blueprint resource with name %s", d.Get("name"))
+	apiClient := m.(*Client).apiClient
+
+	_, err := apiClient.CatalogSources.DeleteUsingDELETE(
+		catalog_sources.NewDeleteUsingDELETEParams().WithSourceID(strfmt.UUID(d.Id())))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	log.Printf("Finished deleting the vra_catalog_source_blueprint resource with name %s", d.Get("name"))
+	return nil
+}

--- a/vra/resource_catalog_source_blueprint_test.go
+++ b/vra/resource_catalog_source_blueprint_test.go
@@ -1,0 +1,67 @@
+package vra
+
+import (
+	"fmt"
+
+	"github.com/vmware/vra-sdk-go/pkg/client/catalog_sources"
+
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccVRACatalogSourceBlueprint_Valid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_catalog_source_blueprint.this"
+	project := "vra_project.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBlueprint(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRACatalogSourceBlueprintDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRACatalogSourceBlueprintValidContentConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resource1, "project_id", project, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "config.sourceProjectId", project, "id"),
+					resource.TestCheckResourceAttr(resource1, "name", "tf-test-catalog-source"),
+					resource.TestCheckResourceAttr(resource1, "type_id", "com.vmw.blueprint"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVRACatalogSourceBlueprintDestroy(s *terraform.State) error {
+	apiClient := testAccProviderVRA.Meta().(*Client).apiClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vra_catalog_source_blueprint" {
+			continue
+		}
+
+		_, err := apiClient.CatalogSources.GetUsingGET(catalog_sources.NewGetUsingGETParams().WithSourceID(strfmt.UUID(rs.Primary.ID)))
+		if err == nil {
+			return fmt.Errorf("resource 'vra_catalog_source_blueprint' still exists with id %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVRACatalogSourceBlueprintValidContentConfig(rInt int) string {
+	return `
+	resource "vra_project" "this" {
+	  name = "tf-test-project"
+	}
+
+	resource "vra_catalog_source_blueprint" "this" {
+ 	  name       = "tf-test-catalog-source"
+  	  project_id = vra_project.this.id
+	}`
+}

--- a/vra/resource_catalog_source_entitlement.go
+++ b/vra/resource_catalog_source_entitlement.go
@@ -1,0 +1,144 @@
+package vra
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/client/catalog_entitlements"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"log"
+)
+
+func resourceCatalogSourceEntitlement() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCatalogSourceEntitlementCreate,
+		Delete: resourceCatalogSourceEntitlementDelete,
+		Read:   resourceCatalogSourceEntitlementRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"catalog_source_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"definition": &schema.Schema{
+				Type:     schema.TypeSet,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"number_of_items": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"source_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"project_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceCatalogSourceEntitlementCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("starting to create vra_catalog_source_entitlement resource")
+
+	apiClient := m.(*Client).apiClient
+
+	catalogSourceID := strfmt.UUID(d.Get("catalog_source_id").(string))
+
+	contentDefinition := models.ContentDefinition{
+		ID:   &catalogSourceID,
+		Type: withString("CatalogSourceIdentifier"),
+	}
+
+	entitlement := models.Entitlement{
+		Definition: &contentDefinition,
+		ProjectID:  withString(d.Get("project_id").(string)),
+	}
+
+	_, createResp, err := apiClient.CatalogEntitlements.CreateEntitlementUsingPOST(
+		catalog_entitlements.NewCreateEntitlementUsingPOSTParams().WithEntitlement(&entitlement))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(createResp.GetPayload().ID.String())
+	log.Printf("Finished creating vra_catalog_source_entitlement resource with name %s", d.Get("name"))
+
+	return resourceCatalogSourceEntitlementRead(d, m)
+}
+
+func resourceCatalogSourceEntitlementRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Reading the vra_catalog_source_entitlement resource with name %s", d.Get("name"))
+	apiClient := m.(*Client).apiClient
+
+	resp, err := apiClient.CatalogEntitlements.GetEntitlementsUsingGET(
+		catalog_entitlements.NewGetEntitlementsUsingGETParams().WithProjectID(withString(d.Get("project_id").(string))))
+
+	if err != nil {
+		return err
+	}
+
+	setFields := func(entitlement *models.Entitlement) {
+		d.SetId(entitlement.ID.String())
+		d.Set("project_id", entitlement.ProjectID)
+		d.Set("definition", flattenContentDefinition(entitlement.Definition))
+	}
+
+	if len(resp.Payload) > 0 {
+		for _, entitlement := range resp.Payload {
+			if entitlement.Definition.ID.String() == d.Get("catalog_source_id").(string) {
+				setFields(entitlement)
+				log.Printf("Finished reading the vra_catalog_source_entitlement resource with name %s", d.Get("name"))
+				return nil
+			}
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceCatalogSourceEntitlementDelete(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to delete the vra_catalog_source_entitlement resource with name %s", d.Get("name"))
+	apiClient := m.(*Client).apiClient
+
+	_, err := apiClient.CatalogEntitlements.DeleteEntitlementUsingDELETE(
+		catalog_entitlements.NewDeleteEntitlementUsingDELETEParams().WithID(strfmt.UUID(d.Id())))
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	log.Printf("Finished deleting the vra_catalog_source_entitlement resource with name %s", d.Get("name"))
+	return nil
+}

--- a/vra/resource_catalog_source_entitlement_test.go
+++ b/vra/resource_catalog_source_entitlement_test.go
@@ -1,0 +1,72 @@
+package vra
+
+import (
+	"fmt"
+
+	"github.com/vmware/vra-sdk-go/pkg/client/catalog_sources"
+
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccVRACatalogSourceEntitlement_Valid(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_catalog_source_entitlement.this"
+	blueprintCatalogSource := "vra_catalog_source_blueprint.this"
+	project := "vra_project.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBlueprint(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRACatalogSourceEntitlementDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRACatalogSourceEntitlementValidContentConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resource1, "definition.0.id", blueprintCatalogSource, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "definition.0.name", blueprintCatalogSource, "name"),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", project, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVRACatalogSourceEntitlementDestroy(s *terraform.State) error {
+	apiClient := testAccProviderVRA.Meta().(*Client).apiClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vra_catalog_source_entitlement" {
+			continue
+		}
+
+		_, err := apiClient.CatalogSources.GetUsingGET(catalog_sources.NewGetUsingGETParams().WithSourceID(strfmt.UUID(rs.Primary.ID)))
+		if err == nil {
+			return fmt.Errorf("resource 'vra_catalog_source_entitlement' still exists with id %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVRACatalogSourceEntitlementValidContentConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "vra_project" "this" {
+	  name = "tf-test-project-%d"
+	}
+
+	resource "vra_catalog_source_blueprint" "this" {
+ 	  name       = "tf-test-catalog-source-%d"
+  	  project_id = vra_project.this.id
+	}
+
+	resource "vra_catalog_source_entitlement" "this" {
+  	  catalog_source_id = vra_catalog_source_blueprint.this.id
+	  project_id        = vra_project.this.id
+	}`, rInt, rInt)
+}

--- a/vra/structure.go
+++ b/vra/structure.go
@@ -160,3 +160,31 @@ func expandInputs(configInputs interface{}) map[string]interface{} {
 
 	return inputs
 }
+
+// expandCatalogSourceConfig will convert the interface into a map of interface
+func expandCatalogSourceConfig(catalogSourceConfig interface{}) map[string]interface{} {
+	config := make(map[string]interface{})
+	for key, value := range catalogSourceConfig.(map[string]interface{}) {
+		if value != nil {
+			config[key] = fmt.Sprint(value)
+		}
+	}
+
+	return config
+}
+
+// flattenContentDefinition will convert the ContentDefinition to map of interface
+func flattenContentDefinition(contentDefinition *models.ContentDefinition) interface{} {
+	helper := make(map[string]interface{})
+
+	helper["description"] = contentDefinition.Description
+	helper["id"] = contentDefinition.ID
+	helper["name"] = contentDefinition.Name
+	helper["number_of_items"] = contentDefinition.NumItems
+	helper["source_type"] = contentDefinition.SourceType
+	helper["type"] = contentDefinition.Type
+
+	definition := make([]interface{}, 0)
+	definition = append(definition, helper)
+	return definition
+}


### PR DESCRIPTION
This commit adds the resources and data sources needed in order to create
a blueprint version, release/unrelease it, create a new catalog source
for Cloud Assembly blueprint type, create a content entitlement (content
sharing) so that a blueprint created in Cloud Assembly is availble in
Service Broker Catalog.

Fixes #177.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>