### PR TITLE
Fix incorrect deployment update plans

### DIFF
--- a/vra/resource_deployment_test.go
+++ b/vra/resource_deployment_test.go
@@ -191,3 +191,91 @@ func testAccCheckVRADeploymentBlueprintConfig(rInt int) string {
 	  project_id = data.vra_project.this.id
 	}`, projectName, rInt, blueprintID, blueprintVersion)
 }
+
+func TestAccVRADeployment_test(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource1 := "vra_deployment.this"
+	project := "data.vra_project.this"
+	catalogItem := "data.vra_catalog_item.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckDeployment(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRADeploymentCreateConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(resource1, "name", regexp.MustCompile("^test-deployment-"+strconv.Itoa(rInt))),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", project, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "catalog_item_id", catalogItem, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "inputs.0.cpuCores", catalogItem, "1"),
+				),
+			},
+			{
+				Config: testAccCheckVRADeploymentUpdateConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(resource1, "name", regexp.MustCompile("^test-deployment-"+strconv.Itoa(rInt))),
+					resource.TestCheckResourceAttrPair(resource1, "project_id", project, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "catalog_item_id", catalogItem, "id"),
+					resource.TestCheckResourceAttrPair(resource1, "inputs.0.cpuCores", catalogItem, "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVRADeploymentCreateConfig(rInt int) string {
+	// Need valid details since this is creating a real deployment
+	catalogItemName := os.Getenv("VRA_CATALOG_ITEM_NAME")
+	projectName := os.Getenv("VRA_PROJECT_NAME")
+
+	return fmt.Sprintf(`
+	data "vra_project" "this" {
+	  name = "%s"
+	}
+
+	data "vra_catalog_item" "this" {
+	  name = "%s"
+	}
+
+	resource "vra_deployment" "this" {
+	  name        = "test-deployment-%d"
+	  description = "terraform test deployment"
+
+	  catalog_item_id 		= data.vra_catalog_item.this.id
+	  catalog_item_version 	= 2
+	  project_id = data.vra_project.this.id
+
+	  inputs = {
+        cpuCores = 1
+	  }
+	}`, projectName, catalogItemName, rInt)
+}
+
+func testAccCheckVRADeploymentUpdateConfig(rInt int) string {
+	// Need valid details since this is creating a real deployment
+	catalogItemName := os.Getenv("VRA_CATALOG_ITEM_NAME")
+	projectName := os.Getenv("VRA_PROJECT_NAME")
+
+	return fmt.Sprintf(`
+	data "vra_project" "this" {
+	  name = "%s"
+	}
+
+	data "vra_catalog_item" "this" {
+	  name = "%s"
+	}
+
+	resource "vra_deployment" "this" {
+	  name        = "test-deployment-%d"
+	  description = "terraform test deployment"
+
+	  catalog_item_id 		= data.vra_catalog_item.this.id
+	  catalog_item_version 	= 2
+	  project_id = data.vra_project.this.id
+
+	  inputs = {
+        cpuCores = 2
+	  }
+	}`, projectName, catalogItemName, rInt)
+}


### PR DESCRIPTION
If a deployment is requested only with required inputs, upon successful
creation of deployment, the state file includes inputs not only that are
provided by the user in the config file, but also those with default
values in the blueprint/catalog item. Hence, when the plan/apply command
is run next time, the plan shows that the deployment state is changed and
it needs to update those deployment inputs that has default value with null.

This change introduces a new attribute 'inputs_including_defaults' with all
the inputs, i.e. both user provided and those with default values but not
provided by the user. The existing attribute 'inputs' includes only the
user provided inputs. These inputs provided by the user in the config file
are updated when deployment is updated in vRA directly and the terraform
state file is out of sync.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>