### PR TITLE
Fix deployment state persistence during apply commands

### DIFF
--- a/vra/deployment_request.go
+++ b/vra/deployment_request.go
@@ -8,7 +8,7 @@ import (
 // deploymentRequest returns the schema to use for the last_request property
 func deploymentRequestSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{

--- a/vra/resource.go
+++ b/vra/resource.go
@@ -10,7 +10,7 @@ import (
 // resourcesSchema returns the schema to use for the resource property
 func resourcesSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Due to known limitations with TypeSet and recommendation described at
https://github.com/hashicorp/terraform/issues/25164#issuecomment-644356706,
the 'last_request' and 'resources' attributes in vra_deployment resource
are changed to TypeList so that they are updated correctly in the state
file at the time of running 'apply' command to update deployment resource,
which otherwise requires a 'refresh' command to update state file with the
correct state.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>