### PR TITLE
Make data collector id optional for NSX-T/V cloud accounts

### DIFF
--- a/examples/cloud_account_nsxt/main.tf
+++ b/examples/cloud_account_nsxt/main.tf
@@ -1,10 +1,12 @@
 provider "vra" {
   url           = var.url
   refresh_token = var.refresh_token
+  insecure      = var.insecure
 }
 
 data "vra_data_collector" "dc" {
-  name = var.datacollector
+  count = var.cloud_proxy != "" ? 1 : 0
+  name  = var.cloud_proxy
 }
 
 resource "vra_cloud_account_nsxt" "this" {
@@ -13,7 +15,7 @@ resource "vra_cloud_account_nsxt" "this" {
   username    = var.username
   password    = var.password
   hostname    = var.hostname
-  dc_id        = data.vra_data_collector.dc.id
+  dc_id       = var.cloud_proxy != "" ? data.vra_data_collector.dc[0].id : ""
 
   accept_self_signed_cert = true
 

--- a/examples/cloud_account_nsxt/terraform.tfvars.sample
+++ b/examples/cloud_account_nsxt/terraform.tfvars.sample
@@ -1,6 +1,7 @@
 refresh_token = ""
 url = ""
+insecure = ""
 username = ""
 password = ""
 hostname = ""
-datacollector = ""
+cloud_proxy = ""

--- a/examples/cloud_account_nsxt/variables.tf
+++ b/examples/cloud_account_nsxt/variables.tf
@@ -4,6 +4,8 @@ variable "refresh_token" {
 variable "url" {
 }
 
+variable "insecure" {}
+
 variable "username" {
 }
 
@@ -13,6 +15,6 @@ variable "password" {
 variable "hostname" {
 }
 
-variable "datacollector" {
+variable "cloud_proxy" {
 }
 

--- a/examples/cloud_account_nsxv/main.tf
+++ b/examples/cloud_account_nsxv/main.tf
@@ -1,10 +1,12 @@
 provider "vra" {
   url           = var.url
   refresh_token = var.refresh_token
+  insecure      = var.insecure
 }
 
 data "vra_data_collector" "dc" {
-  name = var.datacollector
+  count = var.cloud_proxy != "" ? 1 : 0
+  name  = var.cloud_proxy
 }
 
 resource "vra_cloud_account_nsxv" "this" {
@@ -13,7 +15,7 @@ resource "vra_cloud_account_nsxv" "this" {
   username    = var.username
   password    = var.password
   hostname    = var.hostname
-  dc_id        = data.vra_data_collector.dc.id
+  dc_id       = var.cloud_proxy != "" ? data.vra_data_collector.dc[0].id : ""
 
   accept_self_signed_cert = true
 

--- a/examples/cloud_account_nsxv/terraform.tfvars.sample
+++ b/examples/cloud_account_nsxv/terraform.tfvars.sample
@@ -1,6 +1,7 @@
 refresh_token = ""
 url = ""
+insecure = ""
 username = ""
 password = ""
 hostname = ""
-datacollector = ""
+cloud_proxy = ""

--- a/examples/cloud_account_nsxv/variables.tf
+++ b/examples/cloud_account_nsxv/variables.tf
@@ -4,6 +4,8 @@ variable "refresh_token" {
 variable "url" {
 }
 
+variable "insecure" {}
+
 variable "username" {
 }
 
@@ -13,6 +15,6 @@ variable "password" {
 variable "hostname" {
 }
 
-variable "datacollector" {
+variable "cloud_proxy" {
 }
 

--- a/vra/resource_cloud_account_nsxt.go
+++ b/vra/resource_cloud_account_nsxt.go
@@ -34,7 +34,7 @@ func resourceCloudAccountNSXT() *schema.Resource {
 			},
 			"dc_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/vra/resource_cloud_account_nsxv.go
+++ b/vra/resource_cloud_account_nsxv.go
@@ -34,7 +34,7 @@ func resourceCloudAccountNSXV() *schema.Resource {
 			},
 			"dc_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
For creating a NSX-T/V cloud account, one doesn't need data collector
(dcId) with vRA 8.x. It is required only for vRA Cloud.

This commit makes the dcId as optional in schema for NSX-T/V cloud
account resources.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>