### PR TITLE
Lock deployments apiVersion to 2019-01-15

### DIFF
--- a/vra/client.go
+++ b/vra/client.go
@@ -20,7 +20,8 @@ import (
 
 // API Versions
 const (
-	CatalogAPIVersion = "2019-01-15"
+	CatalogAPIVersion     = "2019-01-15"
+	DeploymentsAPIVersion = "2019-01-15"
 )
 
 const IncreasedTimeOut = 60 * time.Second

--- a/vra/data_source_deployment.go
+++ b/vra/data_source_deployment.go
@@ -195,6 +195,7 @@ func dataSourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 			WithExpandProject(withBool(expandProject)).
 			WithExpandResources(withBool(expandResources)).
 			WithExpandLastRequest(withBool(expandLastRequest)).
+			WithAPIVersion(withString(DeploymentsAPIVersion)).
 			WithTimeout(IncreasedTimeOut))
 
 	if err != nil {

--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -319,6 +319,7 @@ func resourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 			WithExpandResources(withBool(true)).
 			WithExpandLastRequest(withBool(true)).
 			WithExpandProject(withBool(expandProject)).
+			WithAPIVersion(withString(DeploymentsAPIVersion)).
 			WithTimeout(IncreasedTimeOut))
 	if err != nil {
 		switch err.(type) {
@@ -553,7 +554,8 @@ func deploymentStatusRefreshFunc(apiClient client.MulticloudIaaS, id string) res
 		ret, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
 			deployments.NewGetDeploymentByIDUsingGETParams().
 				WithDepID(strfmt.UUID(id)).
-				WithExpandLastRequest(withBool(true)))
+				WithExpandLastRequest(withBool(true)).
+				WithAPIVersion(withString(DeploymentsAPIVersion)))
 		if err != nil {
 			return id, models.DeploymentStatusCREATEFAILED, err
 		}
@@ -865,6 +867,7 @@ func deploymentActionStatusRefreshFunc(apiClient client.MulticloudIaaS, deployme
 			deployments.NewGetDeploymentByIDUsingGETParams().
 				WithDepID(deploymentUUID).
 				WithExpandLastRequest(withBool(true)).
+				WithAPIVersion(withString(DeploymentsAPIVersion)).
 				WithTimeout(IncreasedTimeOut))
 		if err != nil {
 			return "", models.DeploymentRequestStatusFAILED, err


### PR DESCRIPTION
With deployments apiVersion 2020-08-25, there are some changes that
are not backward compatible. To let the users continue to use the
provider with vRA 8.0, and 8.1, the deployments apiVersion is now
locked to 2019-01-15.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>