### PR TITLE
Add support for constraints in Project resoruce and data source

### DIFF
--- a/examples/project/main.tf
+++ b/examples/project/main.tf
@@ -32,6 +32,35 @@ resource "vra_project" "this" {
   operation_timeout = 6000
 
   machine_naming_template = "$${resource.name}-$${####}"
+
+  constraints {
+    extensibility {
+      expression = "foo:bar"
+      mandatory  = false
+    }
+    extensibility {
+      expression = "environment:Test"
+      mandatory  = true
+    }
+
+    network {
+      expression = "foo:bar"
+      mandatory  = false
+    }
+    network {
+      expression = "environment:Test"
+      mandatory  = true
+    }
+
+    storage {
+      expression = "foo:bar"
+      mandatory  = false
+    }
+    storage {
+      expression = "environment:Test"
+      mandatory  = true
+    }
+  }
 }
 
 data "vra_project" "this" {

--- a/vra/constraints.go
+++ b/vra/constraints.go
@@ -43,8 +43,24 @@ func expandConstraints(configConstraints []interface{}) []*models.Constraint {
 	return constraints
 }
 
-/*
-func flattenConstraints(constraints []*models.Constraint) []interface{} {
+func expandConstraintsForProject(configConstraints []interface{}) []models.Constraint {
+	constraints := make([]models.Constraint, 0, len(configConstraints))
+
+	for _, configConstraint := range configConstraints {
+		constraintMap := configConstraint.(map[string]interface{})
+
+		constraint := models.Constraint{
+			Mandatory:  withBool(constraintMap["mandatory"].(bool)),
+			Expression: withString(constraintMap["expression"].(string)),
+		}
+
+		constraints = append(constraints, constraint)
+	}
+
+	return constraints
+}
+
+func flattenConstraints(constraints []models.Constraint) []interface{} {
 	if len(constraints) == 0 {
 		return make([]interface{}, 0)
 	}
@@ -61,4 +77,3 @@ func flattenConstraints(constraints []*models.Constraint) []interface{} {
 
 	return configConstraints
 }
-*/

--- a/vra/data_source_project.go
+++ b/vra/data_source_project.go
@@ -15,60 +15,83 @@ func dataSourceProject() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"administrators": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Optional:    true,
+				Description: "List of administrator users associated with the project. Only administrators can manage project's configuration.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
+			"constraints": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "List of storage, network and extensibility constraints to be applied when provisioning through this project.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"extensibility": constraintsSchema(),
+						"network":       constraintsSchema(),
+						"storage":       constraintsSchema(),
+					},
+				},
+			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "A human-friendly description.",
 			},
 			"machine_naming_template": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The naming template to be used for resources provisioned in this project.",
 			},
 			"members": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Optional:    true,
+				Description: "List of member users associated with the project.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "A human-friendly name used as an identifier in APIs that support this option.",
 			},
 			"operation_timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The timeout that should be used for Blueprint operations and Provisioning tasks. The timeout is in seconds.",
 			},
 			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The id of this project resource.",
 			},
 			"shared_resources": {
-				Type:     schema.TypeBool,
-				Computed: true,
-				Optional: true,
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Specifies whether the resources in this projects are shared or not. If not set default will be used.",
 			},
 			"viewers": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Optional:    true,
+				Description: "List of viewer users associated with the project.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			"zone_assignments": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of configurations for zone assignment to a project.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cpu_limit": {
@@ -126,6 +149,7 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	setFields := func(project *models.Project) {
 		d.SetId(*project.ID)
 		d.Set("administrators", flattenUserList(project.Administrators))
+		d.Set("constraints", flattenProjectConstraints(project.Constraints))
 		d.Set("description", project.Description)
 		d.Set("machine_naming_template", project.MachineNamingTemplate)
 		d.Set("members", flattenUserList(project.Members))

--- a/vra/resource_project.go
+++ b/vra/resource_project.go
@@ -18,50 +18,72 @@ func resourceProject() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"administrators": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of administrator users associated with the project. Only administrators can manage project's configuration.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
+			"constraints": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "List of storage, network and extensibility constraints to be applied when provisioning through this project.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"extensibility": constraintsSchema(),
+						"network":       constraintsSchema(),
+						"storage":       constraintsSchema(),
+					},
+				},
+			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A human-friendly description.",
 			},
 			"machine_naming_template": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The naming template to be used for resources provisioned in this project.",
 			},
 			"members": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of member users associated with the project.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A human-friendly name used as an identifier in APIs that support this option.",
 			},
 			"operation_timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The timeout that should be used for Blueprint operations and Provisioning tasks. The timeout is in seconds.",
 			},
 			"shared_resources": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Specifies whether the resources in this projects are shared or not. If not set default will be used.",
 			},
 			"viewers": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of viewer users associated with the project.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 			"zone_assignments": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of configurations for zone assignment to a project.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cpu_limit": {
@@ -105,6 +127,7 @@ func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*Client).apiClient
 
 	administrators := expandUserList(d.Get("administrators").(*schema.Set).List())
+	constraints := expandProjectConstraints(d.Get("constraints").(*schema.Set).List())
 	description := d.Get("description").(string)
 	machineNamingTemplate := d.Get("machine_naming_template").(string)
 	members := expandUserList(d.Get("members").(*schema.Set).List())
@@ -116,6 +139,7 @@ func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
 
 	createResp, err := apiClient.Project.CreateProject(project.NewCreateProjectParams().WithBody(&models.ProjectSpecification{
 		Administrators:               administrators,
+		Constraints:                  constraints,
 		Description:                  description,
 		MachineNamingTemplate:        machineNamingTemplate,
 		Members:                      members,
@@ -147,16 +171,17 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 		}
 		return err
 	}
-	Project := *ret.Payload
-	d.Set("administrators", flattenUserList(Project.Administrators))
-	d.Set("description", Project.Description)
-	d.Set("machine_naming_template", Project.MachineNamingTemplate)
-	d.Set("members", flattenUserList(Project.Members))
-	d.Set("name", Project.Name)
-	d.Set("operation_timeout", Project.OperationTimeout)
-	d.Set("shared_resources", Project.SharedResources)
-	d.Set("viewers", flattenUserList(Project.Viewers))
-	d.Set("zone_assignments", flattenZoneAssignment(Project.Zones))
+	project := *ret.Payload
+	d.Set("administrators", flattenUserList(project.Administrators))
+	d.Set("constraints", flattenProjectConstraints(project.Constraints))
+	d.Set("description", project.Description)
+	d.Set("machine_naming_template", project.MachineNamingTemplate)
+	d.Set("members", flattenUserList(project.Members))
+	d.Set("name", project.Name)
+	d.Set("operation_timeout", project.OperationTimeout)
+	d.Set("shared_resources", project.SharedResources)
+	d.Set("viewers", flattenUserList(project.Viewers))
+	d.Set("zone_assignments", flattenZoneAssignment(project.Zones))
 
 	return nil
 }
@@ -274,5 +299,47 @@ func flattenZoneAssignment(list []*models.ZoneAssignmentConfig) []map[string]int
 
 		result = append(result, l)
 	}
+	return result
+}
+
+func expandProjectConstraints(configProjectConstraints []interface{}) map[string][]models.Constraint {
+	projectConstraints := make(map[string][]models.Constraint)
+
+	for _, configProjectConstraint := range configProjectConstraints {
+		configConstraints := configProjectConstraint.(map[string]interface{})
+
+		if v, ok := configConstraints["extensibility"]; ok {
+			projectConstraints["extensibility"] = expandConstraintsForProject(v.(*schema.Set).List())
+		}
+
+		if v, ok := configConstraints["network"]; ok {
+			projectConstraints["network"] = expandConstraintsForProject(v.(*schema.Set).List())
+		}
+
+		if v, ok := configConstraints["storage"]; ok {
+			projectConstraints["storage"] = expandConstraintsForProject(v.(*schema.Set).List())
+		}
+	}
+
+	return projectConstraints
+}
+
+func flattenProjectConstraints(projectConstraints map[string][]models.Constraint) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, 1)
+
+	helper := make(map[string]interface{})
+	if v, ok := projectConstraints["extensibility"]; ok && len(v) > 0 {
+		helper["extensibility"] = flattenConstraints(v)
+	}
+
+	if v, ok := projectConstraints["network"]; ok && len(v) > 0 {
+		helper["network"] = flattenConstraints(v)
+	}
+
+	if v, ok := projectConstraints["storage"]; ok && len(v) > 0 {
+		helper["storage"] = flattenConstraints(v)
+	}
+
+	result = append(result, helper)
 	return result
 }


### PR DESCRIPTION
This commit adds the ability to specify extensibility, project and storage
constraints while creating a new project. These attributes are also supported
when an existing project is imported and even in project data source.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>