### PR TITLE
New import only resource vra_fabric_network_vsphere

### DIFF
--- a/examples/fabric_network_vsphere/README.md
+++ b/examples/fabric_network_vsphere/README.md
@@ -26,7 +26,16 @@ This examples assumes a vsphere cloud account is already set up, if not please r
 
 * Setup [cloud\_account\_vsphere](../cloud_account_vsphere/README.md)
 
-To import the resource you must find the ID of the fabric network. This can be done via API calls or by viewing the object in a browser and pulling the ID from the url. (ex value: bea2cb32-ba08-4876-bb6c-9ce8af6cd90c)
+To import the resource you must find the ID of the fabric network. There are a couple of way this ID can be aquired:
+
+1. Use of the vra_fabric_network data source. ex:  
+```
+  data "vra_fabric_network" "subnet" {
+  filter = "name eq '${var.subnet_name}' and cloudAccountId eq '${var.cloud_account_vsphere_id}' and externalRegionId eq '${var.region_id_vsphere}'"
+}
+```
+2. via API calls 
+3. Viewing the object in a browser and pulling the ID from the url. (ex value: bea2cb32-ba08-4876-bb6c-9ce8af6cd90c)
 
 Once the information is added to `terraform.tfvars` the resource can be imported and the manage via:
 

--- a/examples/fabric_network_vsphere/README.md
+++ b/examples/fabric_network_vsphere/README.md
@@ -1,0 +1,57 @@
+# fabric network vsphere example
+
+**__NOTE: THIS RESOURCE TYPE MUST BE IMPORTED. ATTEMPTING TO CREATE IT WILL ERROR__ **
+
+These resources (fabric networks) are discovered in vRA(C) as part of creating a vSphere Cloud Account and can not therefore be "created" or "destroyed" in a traditional sense.
+
+This is an example on how to import a vsphere fabric network resource into terraform and then manage settings on it.
+
+## Getting Started
+
+There are variables which need to be added to terraform.tfvars. The first are for connecting to the vRealize Automation (vRA) endpoint. There are names of cloud_account, region, zone, project, already setup in vRA.
+
+* `url` - The URL for the vRealize Automation (vRA) endpoint
+* `refresh_token` - The refresh token for the vRA account
+* `cidr` - The CIDR specification for the network (ex: 10.0.0.0/24)
+* `gateway` - The default gateway for the network
+* `domain` - The DNS domain machines will be customized with
+
+To facilitate adding these variables, a sample tfvars file can be copied first:
+
+```shell
+cp terraform.tfvars.sample terraform.tfvars
+```
+
+This examples assumes a vsphere cloud account is already set up, if not please refer to vsphere cloud account example
+
+* Setup [cloud\_account\_vsphere](../cloud_account_vsphere/README.md)
+
+To import the resource you must find the ID of the fabric network. This can be done via API calls or by viewing the object in a browser and pulling the ID from the url. (ex value: bea2cb32-ba08-4876-bb6c-9ce8af6cd90c)
+
+Once the information is added to `terraform.tfvars` the resource can be imported and the manage via:
+
+```shell
+terraform import vra_fabric_network_vsphere.simple  <networkID>
+```
+
+If the import is successful output from the command should resemble
+
+```shell
+
+vra_fabric_network_vsphere.simple: importing from ID "<networkID>"
+vra_fabric_network_vsphere.simple: Import Prepared!
+  Prepared vra_fabric_network_vsphere for import
+  vra_fabric_network_vsphere.simple: Refreshing state... [id=<networkID>]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+
+```
+
+To apply your settings you can now perform an apply comand:
+
+```shell
+terraform apply
+```

--- a/examples/fabric_network_vsphere/main.tf
+++ b/examples/fabric_network_vsphere/main.tf
@@ -1,0 +1,19 @@
+
+provider "vra" {
+  url           = var.url
+  refresh_token = var.refresh_token
+  insecure      = "true"
+}
+
+
+
+resource "vra_fabric_network_vsphere" "simple" {
+  cidr            = var.cidr
+  default_gateway = var.gateway
+  domain          = var.domain
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+

--- a/examples/fabric_network_vsphere/terraform.tfvars.sample
+++ b/examples/fabric_network_vsphere/terraform.tfvars.sample
@@ -1,0 +1,6 @@
+refresh_token = ""
+url = ""
+cidr = ""
+gateway = ""
+domain = ""
+

--- a/examples/fabric_network_vsphere/variables.tf
+++ b/examples/fabric_network_vsphere/variables.tf
@@ -1,0 +1,21 @@
+variable "refresh_token" {
+  description = "API Refresh token"
+}
+
+variable "url" {
+  description = "URL to access the vRA(C) instance"
+}
+
+variable "cidr" {
+  description = "CIDR notation is a compact representation of an IP address and its associated routing prefix"
+}
+
+variable "gateway" {
+  description = "default IPv4 Gateway"
+}
+
+variable "domain" {
+  description = "Domain name for the machine. The domain name is passed to the vSphere machine customization spec."
+}
+
+

--- a/vra/provider.go
+++ b/vra/provider.go
@@ -98,6 +98,7 @@ func Provider() *schema.Provider {
 			"vra_cloud_account_vsphere":      resourceCloudAccountVsphere(),
 			"vra_content_source":             resourceContentSource(),
 			"vra_deployment":                 resourceDeployment(),
+			"vra_fabric_network_vsphere":     resourceVsphereFabricNetwork(),
 			"vra_flavor_profile":             resourceFlavorProfile(),
 			"vra_image_profile":              resourceImageProfile(),
 			"vra_load_balancer":              resourceLoadBalancer(),

--- a/vra/resource_fabric_network.go
+++ b/vra/resource_fabric_network.go
@@ -1,0 +1,213 @@
+package vra
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/vmware/vra-sdk-go/pkg/client/fabric_network"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceVsphereFabricNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVsphereFabricNetworkCreate,
+		Read:   resourceVsphereFabricNetworkRead,
+		Update: resourceVsphereFabricNetworkUpdate,
+		Delete: resourceVsphereFabricNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		SchemaVersion: 1,
+
+		Schema: map[string]*schema.Schema{
+			"cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cloud_account_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"default_gateway": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"default_ipv6_gateway": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dns_search_domains": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"dns_server_addresses": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"external_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ipv6_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"is_public": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"links": linksSchema(),
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"organization_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceVsphereFabricNetworkCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to create vra_fabric_network resource")
+	return errors.New("vra_fabric_network resources are only importable")
+}
+
+func resourceVsphereFabricNetworkRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Reading the vra_fabric_network_vsphere resource with name %s", d.Get("name"))
+	apiClient := m.(*Client).apiClient
+
+	id := d.Id()
+	resp, err := apiClient.FabricNetwork.GetVsphereFabricNetwork(fabric_network.NewGetVsphereFabricNetworkParams().WithID(id))
+	if err != nil {
+		return err
+	}
+
+	VsphereFabricNetwork := *resp.Payload
+	d.Set("cidr", VsphereFabricNetwork.Cidr)
+	d.Set("created_at", VsphereFabricNetwork.CreatedAt)
+	d.Set("cloud_account_ids", VsphereFabricNetwork.CloudAccountIds)
+	d.Set("default_gateway", VsphereFabricNetwork.DefaultGateway)
+	d.Set("defulat_ipv6_gateway", VsphereFabricNetwork.DefaultIPV6Gateway)
+	d.Set("dns_search_domains", VsphereFabricNetwork.DNSSearchDomains)
+	d.Set("dns_server_addresses", VsphereFabricNetwork.DNSServerAddresses)
+	d.Set("domain", VsphereFabricNetwork.Domain)
+	d.Set("ipv6_cidr", VsphereFabricNetwork.IPV6Cidr)
+	d.Set("is_default", VsphereFabricNetwork.IsDefault)
+	d.Set("is_public", VsphereFabricNetwork.IsPublic)
+	d.Set("org_id", VsphereFabricNetwork.OrganizationID)
+	d.Set("name", VsphereFabricNetwork.Name)
+	d.Set("owner", VsphereFabricNetwork.Owner)
+	d.Set("updated_at", VsphereFabricNetwork.UpdatedAt)
+
+	if err := d.Set("tags", flattenTags(VsphereFabricNetwork.Tags)); err != nil {
+		return fmt.Errorf("error setting network ip range tags - error: %v", err)
+	}
+
+	if err := d.Set("links", flattenLinks(VsphereFabricNetwork.Links)); err != nil {
+		return fmt.Errorf("error setting network ip range links - error: %#v", err)
+	}
+
+	log.Printf("Finished reading the vra_fabric_network_vsphere resource with name %s", d.Get("name"))
+
+	return nil
+}
+
+func resourceVsphereFabricNetworkUpdate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to Update vra_fabric_network resource")
+	var dnsSearchDomains []string
+	var dnsServerAddresses []string
+	apiClient := m.(*Client).apiClient
+
+	id := d.Id()
+
+	if v, ok := d.GetOk("dns_search_domains"); ok {
+		if !compareUnique(v.([]interface{})) {
+			return fmt.Errorf("specified dns search domains are not unique")
+		}
+		dnsSearchDomains = expandStringList(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("dns_server_addresses"); ok {
+		if !compareUnique(v.([]interface{})) {
+			return fmt.Errorf("specified dns server addresses are not unique")
+		}
+		dnsServerAddresses = expandStringList(v.([]interface{}))
+	}
+
+	isDefault := d.Get("is_default").(bool)
+	isPublic := d.Get("is_public").(bool)
+
+	VsphereFabricNetworkSpecification := models.FabricNetworkVsphereSpecification{
+		Cidr:               d.Get("cidr").(string),
+		DefaultGateway:     d.Get("default_gateway").(string),
+		DefaultIPV6Gateway: d.Get("default_ipv6_gateway").(string),
+		DNSSearchDomains:   dnsSearchDomains,
+		DNSServerAddresses: dnsServerAddresses,
+		Domain:             d.Get("domain").(string),
+		IPV6Cidr:           d.Get("ipv6_cidr").(string),
+		IsDefault:          withBool(isDefault),
+		IsPublic:           withBool(isPublic),
+		Tags:               expandTags(d.Get("tags").(*schema.Set).List()),
+	}
+
+	log.Printf("[DEBUG]zzz update fabric network vsphere: %#v", VsphereFabricNetworkSpecification)
+	tmpbody := fabric_network.NewUpdatevSphereFabricNetworkParams().WithID(id).WithBody(&VsphereFabricNetworkSpecification)
+	log.Printf("[DEBUG]zzz Tmp Body is %#v", tmpbody.Body)
+	_, err := apiClient.FabricNetwork.UpdatevSphereFabricNetwork(fabric_network.NewUpdatevSphereFabricNetworkParams().WithID(id).WithBody(&VsphereFabricNetworkSpecification))
+	if err != nil {
+		return err
+	}
+	log.Printf("finished Updating vra_fabric_network_vsphere resource")
+	return resourceVsphereFabricNetworkRead(d, m)
+
+}
+
+func resourceVsphereFabricNetworkDelete(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to delete the vra_fabric_network_vsphere resource with name %s", d.Get("name"))
+	return nil
+}

--- a/vra/resource_fabric_network.go
+++ b/vra/resource_fabric_network.go
@@ -140,7 +140,7 @@ func resourceVsphereFabricNetworkRead(d *schema.ResourceData, m interface{}) err
 	d.Set("ipv6_cidr", VsphereFabricNetwork.IPV6Cidr)
 	d.Set("is_default", VsphereFabricNetwork.IsDefault)
 	d.Set("is_public", VsphereFabricNetwork.IsPublic)
-	d.Set("org_id", VsphereFabricNetwork.OrganizationID)
+	d.Set("org_id", VsphereFabricNetwork.OrgID)
 	d.Set("name", VsphereFabricNetwork.Name)
 	d.Set("owner", VsphereFabricNetwork.Owner)
 	d.Set("updated_at", VsphereFabricNetwork.UpdatedAt)
@@ -195,9 +195,6 @@ func resourceVsphereFabricNetworkUpdate(d *schema.ResourceData, m interface{}) e
 		Tags:               expandTags(d.Get("tags").(*schema.Set).List()),
 	}
 
-	log.Printf("[DEBUG]zzz update fabric network vsphere: %#v", VsphereFabricNetworkSpecification)
-	tmpbody := fabric_network.NewUpdatevSphereFabricNetworkParams().WithID(id).WithBody(&VsphereFabricNetworkSpecification)
-	log.Printf("[DEBUG]zzz Tmp Body is %#v", tmpbody.Body)
 	_, err := apiClient.FabricNetwork.UpdatevSphereFabricNetwork(fabric_network.NewUpdatevSphereFabricNetworkParams().WithID(id).WithBody(&VsphereFabricNetworkSpecification))
 	if err != nil {
 		return err

--- a/vra/resource_fabric_network_test.go
+++ b/vra/resource_fabric_network_test.go
@@ -54,7 +54,7 @@ func testAccCheckVRAFabricNetworkVsphereDestroy(s *terraform.State) error {
 		if rs.Type == "vra_fabric_network_vsphere" {
 			_, err := apiClient.FabricNetwork.GetVsphereFabricNetwork(fabric_network.NewGetVsphereFabricNetworkParams().WithID(rs.Primary.ID))
 			if err == nil {
-				return fmt.Errorf("Resource 'vra_fabric_network_vsphere' still exists with id %s", rs.Primary.ID)
+				return fmt.Errorf("Resource 'vra_fabric_network_vsphere' with id %s does not exist", rs.Primary.ID)
 			}
 		}
 

--- a/vra/resource_fabric_network_test.go
+++ b/vra/resource_fabric_network_test.go
@@ -1,0 +1,78 @@
+package vra
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/vmware/vra-sdk-go/pkg/client/fabric_network"
+)
+
+func TestAccVRAFabricNetworkVsphere_importBasic(t *testing.T) {
+	resourceName := "vra_fabric_network_vsphere.this"
+	fabricNetworkID := os.Getenv("VRA_FABRIC_NETWORK_VSPHERE_ID")
+	createErrorRegex := regexp.MustCompile("vra_fabric_network resources are only importable")
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state %#v", s)
+		}
+
+		fabricNetworkVsphereState := s[0]
+		if fabricNetworkID != fabricNetworkVsphereState.ID {
+			return fmt.Errorf("expected fabric network ID of %s,%s received instead", fabricNetworkID, fabricNetworkVsphereState.ID)
+		}
+		return nil
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckVsphere(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRAFabricNetworkVsphereDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckVRAFabricNetworkVsphereConfig(),
+				ExpectError: createErrorRegex,
+			},
+			{
+				Config:           testAccCheckVRAFabricNetworkVsphereConfig(),
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateId:    fabricNetworkID,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}
+
+func testAccCheckVRAFabricNetworkVsphereDestroy(s *terraform.State) error {
+	apiClient := testAccProviderVRA.Meta().(*Client).apiClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "vra_fabric_network_vsphere" {
+			_, err := apiClient.FabricNetwork.GetVsphereFabricNetwork(fabric_network.NewGetVsphereFabricNetworkParams().WithID(rs.Primary.ID))
+			if err == nil {
+				return fmt.Errorf("Resource 'vra_fabric_network_vsphere' still exists with id %s", rs.Primary.ID)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckVRAFabricNetworkVsphereConfig() string {
+	CIDR := os.Getenv("VRA_FABRIC_NETWORK_CIDR")
+	gateway := os.Getenv("VRA_FABRIC_NETWORK_GW")
+	domain := os.Getenv("VRA_FABRIC_NETWORK_DOMAIN")
+	return fmt.Sprintf(`
+	resource "vra_fabric_network_vsphere" "this" {
+		cidr = "%s"
+		default_gateway = "%s"
+		domain = "%s"
+	}	  
+	 
+`, CIDR, gateway, domain)
+}


### PR DESCRIPTION
This PR addresses #224  by adding a new resource ```vra_fabric_network_vsphere```. Because this resource is one discovered by a vsphere cloud account it's behavior differs from other resources. Addition of this resource allows for management of more of the vRA configuration. 

* Create via ```apply``` will cause the provider to throw an error. 
* ```delete``` will simple remove the object from being managed and not affect the actual object in vRA

The process for using this is via
* ```import``` to get it into a managed state
* ```apply``` to apply settings from the config




Signed-off-by: Carlos Tronco <cars@lostroncos.org>