### PR TITLE
Add resource and data source for block_device_snapshot

### DIFF
--- a/examples/block-device/block-device-snapshot/README.md
+++ b/examples/block-device/block-device-snapshot/README.md
@@ -1,0 +1,50 @@
+# Block device resources example
+
+This is an example to create a vSphere storage profile with first class disk type, a block-device (first class) and a snapshot for the block-device.
+
+## Getting Started
+
+There are variables which need to be added to terraform.tfvars. The first are for connecting to the vRealize Automation (vRA) endpoint. There are names of cloud_account, region, zone, project, already setup in vRA.
+
+* `url` - The URL for the vRealize Automation (vRA) endpoint
+* `refresh_token` - The refresh token for the vRA account
+* `cloud_account` - The name of the vsphere cloud account added in vRA
+* `region` - The region within in the cloud account
+* `zone` - The compute placement zone within a region where machines can be placed
+* `project` - The name of the project the current user belongs to
+* `image_name` - The name of the fabric image corresponding to the cloud endpoint, such as ami-id for AWS.
+
+To facilitate adding these variables, a sample tfvars file can be copied first:
+```shell
+cp terraform.tfvars.sample terraform.tfvars
+```
+
+To create a block device, a cloud account, zone and project must be setup. This is an example to create a block devices in a single deployment and attach these disks to a mchine. In this example, two block devices are created (disk1 and disk2) and these disks are added to machine
+
+Follow these examples for setting up specific cloud accounts:
+
+* Setup [cloud\_account\_aws](../cloud_account_aws/README.md)
+* Setup [cloud\_account\_azure](../cloud_account_azure/README.md)
+* Setup [cloud\_account\_gcp](../cloud_account_gcp/README.md)
+* Setup [cloud\_account\_vsphere](../cloud_account_vsphere/README.md)
+
+While the cloud account examples included setting up zones, here is an example
+to setup a zone:
+
+* Setup [zone](../zone/README.md)
+
+To create a project, here is an example
+
+* Setup [project](../project/README.md)
+
+To create a machine, here is an example
+
+* Setup [project](../machine/README.md)
+
+
+Once the information is added to `terraform.tfvars`, the image profile, flavor profile and machine can be created via:
+
+```shell
+terraform init
+terraform apply
+```

--- a/examples/block-device/block-device-snapshot/main.tf
+++ b/examples/block-device/block-device-snapshot/main.tf
@@ -50,6 +50,7 @@ resource "vra_storage_profile" "this" {
   }
 }
 
+// This block device depends on the storage profile created, and the constraints matches the tags of the storage profile
 resource "vra_block_device" "disk1" {
   capacity_in_gb = 10
   name = "terraform_vra_block_device_1"
@@ -63,6 +64,9 @@ resource "vra_block_device" "disk1" {
   }
 }
 
+// This block device will be created based on the dataStore and storagePolicy defined in the custom_properties
+// If the dataStore and storagePolicy are different from the ones used in the vra_storage_profile,
+// then this disk will land into a different datastore
 resource "vra_block_device" "disk2" {
   capacity_in_gb = 10
   name = "terraform_vra_block_device_2"

--- a/examples/block-device/block-device-snapshot/main.tf
+++ b/examples/block-device/block-device-snapshot/main.tf
@@ -1,0 +1,81 @@
+provider "vra" {
+  url           = var.url
+  refresh_token = var.refresh_token
+  insecure = true
+}
+
+data "vra_cloud_account_vsphere" "this" {
+  name = var.cloud_account
+}
+
+data "vra_region" "this" {
+  cloud_account_id = data.vra_cloud_account_vsphere.this.id
+  region           = var.region
+}
+
+data "vra_project" "this" {
+  name = var.project
+}
+
+# Lookup vSphere fabric datastore using its name
+data "vra_fabric_datastore_vsphere" "this" {
+  filter = "name eq '${var.datastore_name}' and externalRegionId eq '${var.region}' and cloudAccountId eq '${data.vra_cloud_account_vsphere.this.id}'"
+}
+
+# Lookup vSphere fabric storage policy using its name
+data "vra_fabric_storage_policy_vsphere" "this" {
+  filter = "name eq '${var.storage_policy_name}' and cloudAccountId eq '${data.vra_cloud_account_vsphere.this.id}'"
+}
+
+//To create block-device snapshots, a Storage Profile for vSphere with first class disk type is needed
+resource "vra_storage_profile" "this" {
+  name         = "vSphere-first-class-disk"
+  description  = "vSphere Storage Profile with first class disk."
+  region_id    = data.vra_region.this.id
+  default_item = true
+
+  disk_properties = {
+    diskType         = "firstClass"
+    provisioningType = "thin" // Supported values: "thin", "thick", "eagerZeroedThick"
+  }
+
+  disk_target_properties = {
+    datastoreId     = data.vra_fabric_datastore_vsphere.this.id
+    storagePolicyId = data.vra_fabric_storage_policy_vsphere.this.id // Remove it if datastore default storage policy needs to be selected.
+  }
+
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+
+resource "vra_block_device" "disk1" {
+  capacity_in_gb = 10
+  name = "terraform_vra_block_device_1"
+  project_id = data.vra_project.this.id
+  depends_on = [vra_storage_profile.this]
+  persistent = true
+
+  constraints {
+    mandatory  = true
+    expression = "foo:bar"
+  }
+}
+
+resource "vra_block_device" "disk2" {
+  capacity_in_gb = 10
+  name = "terraform_vra_block_device_2"
+  project_id = data.vra_project.this.id
+  custom_properties = {
+    "dataStore" = var.datastore_name_b
+    "storagePolicy" = var.storage_policy_name_b
+  }
+  persistent = true
+  purge = true
+}
+
+resource "vra_block_device_snapshot" "snapshot1" {
+  block_device_id = vra_block_device.disk1.id
+  description = "terraform fcd snapshot"
+}

--- a/examples/block-device/block-device-snapshot/terraform.tfvars.sample
+++ b/examples/block-device/block-device-snapshot/terraform.tfvars.sample
@@ -1,0 +1,9 @@
+refresh_token = ""
+url = ""
+cloud_account = ""
+region = ""
+zone = ""
+project = ""
+datastore_name = ""
+storage_policy_name = ""
+

--- a/examples/block-device/block-device-snapshot/terraform.tfvars.sample
+++ b/examples/block-device/block-device-snapshot/terraform.tfvars.sample
@@ -6,4 +6,5 @@ zone = ""
 project = ""
 datastore_name = ""
 storage_policy_name = ""
-
+datastore_name_b = ""
+storage_policy_name_b = ""

--- a/examples/block-device/block-device-snapshot/variables.tf
+++ b/examples/block-device/block-device-snapshot/variables.tf
@@ -1,0 +1,32 @@
+variable "refresh_token" {
+}
+
+variable "url" {
+}
+
+variable "cloud_account" {
+}
+
+variable "region" {
+}
+
+variable "project" {
+
+}
+
+variable "datastore_name" {
+
+}
+
+variable "storage_policy_name" {
+
+}
+
+variable "datastore_name_b" {
+
+}
+
+variable "storage_policy_name_b" {
+
+}
+

--- a/examples/block-device/block-device-snapshot/variables.tf
+++ b/examples/block-device/block-device-snapshot/variables.tf
@@ -29,4 +29,3 @@ variable "datastore_name_b" {
 variable "storage_policy_name_b" {
 
 }
-

--- a/examples/block-device/block-device-snapshot/versions.tf
+++ b/examples/block-device/block-device-snapshot/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    vra = {
+      source = "vmware/vra"
+    }
+  }
+  required_version = ">= 0.12"
+}

--- a/examples/block-device/main.tf
+++ b/examples/block-device/main.tf
@@ -59,7 +59,7 @@ resource "vra_block_device" "disk2" {
 
 resource "vra_machine" "machine" {
   name        = "tf-machine"
-  description = "terrafrom test machine"
+  description = "terraform test machine"
   project_id  = data.vra_project.this.id
   image       = "ubuntu"
   flavor      = "small"

--- a/examples/block-device/versions.tf
+++ b/examples/block-device/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    vra = {
+      source = "vmware/vra"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
-	github.com/vmware/vra-sdk-go v0.2.16
+	github.com/vmware/vra-sdk-go v0.2.17
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/vra-sdk-go v0.2.16 h1:Pd4fH0N8ctUZ4yz/AcIM8qFGX2xXoL9s7pZXsw/Rz9s=
-github.com/vmware/vra-sdk-go v0.2.16/go.mod h1:W6OERth9ssa4FgvS98SOVusGgBNWJs+D4Hq/5ueTgIQ=
+github.com/vmware/vra-sdk-go v0.2.17 h1:p//Li02RVW1OfpksXm+JcwFliSBVxKLbrW1SSwbKsSg=
+github.com/vmware/vra-sdk-go v0.2.17/go.mod h1:W6OERth9ssa4FgvS98SOVusGgBNWJs+D4Hq/5ueTgIQ=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=

--- a/vra/data_source_block_device_snapshots.go
+++ b/vra/data_source_block_device_snapshots.go
@@ -1,0 +1,53 @@
+package vra
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/client/disk"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"log"
+)
+
+func dataSourceBlockDeviceSnapshots() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceBlockDeviceSnapshotRead,
+		Schema: map[string]*schema.Schema{
+			"block_device_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"snapshots": snapshotsSchema(),
+		},
+	}
+}
+
+func dataSourceBlockDeviceSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("Reading the vra_block_device_snapshots data source with block_device_id %s", d.Get("block_device_id"))
+	apiClient := meta.(*Client).apiClient
+
+	var diskSnapshot []*models.DiskSnapshot
+
+	id := d.Get("block_device_id").(string)
+
+	getResp, err := apiClient.Disk.GetDiskSnapshots(disk.NewGetDiskSnapshotsParams().WithID(id))
+
+	if err != nil {
+		return err
+	}
+	diskSnapshot = getResp.GetPayload()
+
+	if len(diskSnapshot) == 0 {
+		log.Printf("No vra_block_device_snapshots data source was found with block_device_id %s", id)
+		return nil
+	}
+
+	d.SetId(id)
+	if err := d.Set("snapshots", flattenSnapshots(diskSnapshot)); err != nil {
+		return fmt.Errorf("error setting vra_block_device_snapshots - error: %#v", err)
+	}
+
+	log.Printf("Finished reading the vra_block_device_snapshots data source with block_device_id %s", id)
+	return nil
+}

--- a/vra/data_source_block_device_snapshots.go
+++ b/vra/data_source_block_device_snapshots.go
@@ -12,7 +12,7 @@ import (
 
 func dataSourceBlockDeviceSnapshots() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceBlockDeviceSnapshotRead,
+		Read: dataSourceBlockDeviceSnapshotsRead,
 		Schema: map[string]*schema.Schema{
 			"block_device_id": {
 				Type:     schema.TypeString,
@@ -23,7 +23,7 @@ func dataSourceBlockDeviceSnapshots() *schema.Resource {
 	}
 }
 
-func dataSourceBlockDeviceSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceBlockDeviceSnapshotsRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("Reading the vra_block_device_snapshots data source with block_device_id %s", d.Get("block_device_id"))
 	apiClient := meta.(*Client).apiClient
 
@@ -39,7 +39,7 @@ func dataSourceBlockDeviceSnapshotRead(d *schema.ResourceData, meta interface{})
 	diskSnapshot = getResp.GetPayload()
 
 	if len(diskSnapshot) == 0 {
-		log.Printf("No vra_block_device_snapshots data source was found with block_device_id %s", id)
+		log.Printf("No snapshots were found with block_device_id %s", id)
 		return nil
 	}
 

--- a/vra/data_source_block_device_snapshots_test.go
+++ b/vra/data_source_block_device_snapshots_test.go
@@ -1,0 +1,40 @@
+package vra
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccBlockDeviceSnapshotRead(t *testing.T) {
+	blockDeviceID := os.Getenv("VRA_BLOCK_DEVICE_ID")
+	blockDevice := "data.vra_block_device_snapshot.snapshot"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckBlockDeviceSnapshot(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBlockDeviceSnapshotConfig(blockDeviceID + "foo"),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("Disk with id '%sfoo' does not exist", blockDeviceID)),
+			},
+			{
+				Config: testAccBlockDeviceSnapshotConfig(blockDeviceID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(blockDevice, "snapshots"),
+					resource.TestCheckResourceAttrSet(blockDevice, "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBlockDeviceSnapshotConfig(blockDeviceID string) string {
+	return fmt.Sprintf(`
+		data "vra_block_device_snapshot" "snapshot" {
+		  block_device_id = "%s"
+		}`, blockDeviceID)
+}

--- a/vra/provider.go
+++ b/vra/provider.go
@@ -46,6 +46,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"vra_block_device":                  dataSourceBlockDevice(),
+			"vra_block_device_snapshots":        dataSourceBlockDeviceSnapshots(),
 			"vra_blueprint":                     dataSourceBlueprint(),
 			"vra_blueprint_version":             dataSourceBlueprintVersion(),
 			"vra_catalog_item":                  dataSourceCatalogItem(),
@@ -86,6 +87,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"vra_block_device":               resourceBlockDevice(),
+			"vra_block_device_snapshot":      resourceBlockDeviceSnapshot(),
 			"vra_blueprint":                  resourceBlueprint(),
 			"vra_blueprint_version":          resourceBlueprintVersion(),
 			"vra_catalog_source_blueprint":   resourceCatalogSourceBlueprint(),

--- a/vra/provider_test.go
+++ b/vra/provider_test.go
@@ -102,6 +102,27 @@ func testAccPreCheckBlockDevice(t *testing.T) {
 	}
 }
 
+func testAccPreCheckBlockDeviceSnapshotResource(t *testing.T) {
+	if os.Getenv("VRA_REFRESH_TOKEN") == "" && os.Getenv("VRA_ACCESS_TOKEN") == "" {
+		t.Fatal("VRA_REFRESH_TOKEN or VRA_ACCESS_TOKEN must be set for acceptance tests")
+	}
+
+	envVars := [...]string{
+		"VRA_URL",
+		"VRA_VSPHERE_CLOUD_ACCOUNT_NAME",
+		"VRA_REGION",
+		"VRA_PROJECT",
+		"VRA_VSPHERE_DATASTORE_NAME",
+		"VRA_VSPHERE_STORAGE_POLICY_NAME",
+	}
+
+	for _, name := range envVars {
+		if v := os.Getenv(name); v == "" {
+			t.Fatalf("%s must be set for acceptance tests\n", name)
+		}
+	}
+}
+
 func testAccPreCheckImageProfile(t *testing.T) {
 	if os.Getenv("VRA_REFRESH_TOKEN") == "" && os.Getenv("VRA_ACCESS_TOKEN") == "" {
 		t.Fatal("VRA_REFRESH_TOKEN or VRA_ACCESS_TOKEN must be set for acceptance tests")
@@ -265,6 +286,22 @@ func testAccPreCheckVsphereForStoragePolicy(t *testing.T) {
 	envVars := [...]string{
 		//"VRA_URL",
 		"VRA_VSPHERE_STORAGE_POLICY_NAME",
+	}
+
+	for _, name := range envVars {
+		if v := os.Getenv(name); v == "" {
+			t.Fatalf("%s must be set for acceptance tests\n", name)
+		}
+	}
+}
+
+func testAccPreCheckBlockDeviceSnapshot(t *testing.T) {
+	testAccPreCheckVra(t)
+
+	// The vCenter should have already been added into the vRA
+	// Set the VRA_BLOCK_DEVICE_ID to an existing block device id which has snapshots created
+	envVars := [...]string{
+		"VRA_BLOCK_DEVICE_ID",
 	}
 
 	for _, name := range envVars {

--- a/vra/resource_block_device_snapshot.go
+++ b/vra/resource_block_device_snapshot.go
@@ -1,0 +1,246 @@
+package vra
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/vmware/vra-sdk-go/pkg/client"
+	"github.com/vmware/vra-sdk-go/pkg/client/disk"
+	"github.com/vmware/vra-sdk-go/pkg/client/request"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceBlockDeviceSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBlockDeviceSnapshotCreate,
+		Read:   resourceBlockDeviceSnapshotRead,
+		Update: resourceBlockDeviceSnapshotUpdate,
+		Delete: resourceBlockDeviceSnapshotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"block_device_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_current": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"links": linksSchema(),
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func resourceBlockDeviceSnapshotCreate(d *schema.ResourceData, m interface{}) error {
+	log.Printf("Starting to create vra_block_device_snapshot resource")
+	apiClient := m.(*Client).apiClient
+
+	description := d.Get("description").(string)
+	id := d.Get("block_device_id").(string)
+
+	DiskSnapshotSpecification := models.DiskSnapshotSpecification{
+		Description: description,
+	}
+
+	log.Printf("[DEBUG] create vra_block_device_snapshot: %#v", DiskSnapshotSpecification)
+	createDiskSnapshotCreated, _, err := apiClient.Disk.CreateFirstClassDiskSnapshot(disk.NewCreateFirstClassDiskSnapshotParams().WithID(id).WithBody(&DiskSnapshotSpecification))
+	if err != nil {
+		return err
+	}
+
+	stateChangeFunc := resource.StateChangeConf{
+		Delay:      5 * time.Second,
+		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
+		Refresh:    BlockDeviceSnapshotStateRefreshFunc(*apiClient, *createDiskSnapshotCreated.Payload.ID),
+		Target:     []string{models.RequestTrackerStatusFINISHED},
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		MinTimeout: 5 * time.Second,
+	}
+
+	_, err = stateChangeFunc.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Finished to create vra_block_device_snapshot resource with for vra_block_device: %s", id)
+
+	return findCreatedBlockDeviceSnapshot(d, m)
+}
+
+func BlockDeviceSnapshotStateRefreshFunc(apiClient client.MulticloudIaaS, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		ret, err := apiClient.Request.GetRequestTracker(request.NewGetRequestTrackerParams().WithID(id))
+		if err != nil {
+			return "", models.RequestTrackerStatusFAILED, err
+		}
+
+		status := ret.Payload.Status
+		switch *status {
+		case models.RequestTrackerStatusFAILED:
+			return []string{""}, *status, fmt.Errorf(ret.Payload.Message)
+		case models.RequestTrackerStatusINPROGRESS:
+			return [...]string{id}, *status, nil
+		case models.RequestTrackerStatusFINISHED:
+			snapshotID := *ret.Payload.ID
+			return snapshotID, *status, nil
+		default:
+			return [...]string{id}, ret.Payload.Message, fmt.Errorf("BlockDeviceSnapshotStateRefreshFunc: unknown status %v", *status)
+		}
+	}
+}
+
+func findCreatedBlockDeviceSnapshot(d *schema.ResourceData, m interface{}) error {
+	blockDeviceID := d.Get("block_device_id").(string)
+	log.Printf("Reading the vra_block_device_snapshot resource for vra_block_device %s ", blockDeviceID)
+	apiClient := m.(*Client).apiClient
+
+	resp, err := apiClient.Disk.GetDiskSnapshots(disk.NewGetDiskSnapshotsParams().WithID(blockDeviceID))
+	// TODO need to change to the correct behavior after the API is updated
+	//resp, err := apiClient.Disk.GetDiskSnapshot(disk.NewGetDiskSnapshotParams().WithID(blockDeviceID).WithId1(d.Id()))
+	if err != nil {
+		switch err.(type) {
+		case *disk.GetDiskSnapshotNotFound:
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	errMsg := "failed to find the created snapshot for the vra_block_device_snapshot resource with id %s"
+
+	diskSnapshots := resp.Payload
+	if len(diskSnapshots) < 1 {
+		return fmt.Errorf(errMsg, d.Get("id"))
+	}
+
+	for _, diskSnapshot := range diskSnapshots {
+		if diskSnapshot.IsCurrent {
+			d.Set("created_at", diskSnapshot.CreatedAt)
+			d.Set("description", diskSnapshot.Desc)
+			d.Set("name", diskSnapshot.Name)
+			d.SetId(*diskSnapshot.ID)
+			d.Set("is_current", diskSnapshot.IsCurrent)
+			d.Set("org_id", diskSnapshot.OrgID)
+			d.Set("owner", diskSnapshot.Owner)
+			d.Set("updated_at", diskSnapshot.UpdatedAt)
+			d.Set("links", flattenLinks(diskSnapshot.Links))
+			log.Printf("Finished reading the vra_block_device_snapshot resource with id %s", *diskSnapshot.ID)
+			return nil
+		}
+	}
+
+	return fmt.Errorf(errMsg, d.Get("id"))
+}
+
+func resourceBlockDeviceSnapshotRead(d *schema.ResourceData, m interface{}) error {
+	blockDeviceID := d.Get("block_device_id").(string)
+	log.Printf("Reading the vra_block_device_snapshot resource for vra_block_device %s ", blockDeviceID)
+	apiClient := m.(*Client).apiClient
+
+	resp, err := apiClient.Disk.GetDiskSnapshot(disk.NewGetDiskSnapshotParams().WithID(blockDeviceID).WithId1(d.Id()))
+	if err != nil {
+		switch err.(type) {
+		case *disk.GetDiskSnapshotNotFound:
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	diskSnapshot := resp.Payload
+
+	d.SetId(*diskSnapshot.ID)
+	d.Set("created_at", diskSnapshot.CreatedAt)
+	d.Set("description", diskSnapshot.Desc)
+	d.Set("is_current", diskSnapshot.IsCurrent)
+	d.Set("name", diskSnapshot.Name)
+	d.Set("org_id", diskSnapshot.OrgID)
+	d.Set("owner", diskSnapshot.Owner)
+	d.Set("updated_at", diskSnapshot.UpdatedAt)
+
+	if err := d.Set("links", flattenLinks(diskSnapshot.Links)); err != nil {
+		return fmt.Errorf("error setting vra_block_device_snapshot links - error: %#v", err)
+	}
+
+	log.Printf("Finished reading the vra_block_device_snapshot resource with id %s", *diskSnapshot.ID)
+	return nil
+}
+
+func resourceBlockDeviceSnapshotUpdate(d *schema.ResourceData, m interface{}) error {
+	return fmt.Errorf("update vra_block_device_snapshot is not supported")
+}
+
+func resourceBlockDeviceSnapshotDelete(d *schema.ResourceData, m interface{}) error {
+	blockDeviceID := d.Get("block_device_id").(string)
+	snapshotID := d.Id()
+	log.Printf("Starting to delete the vra_block_device_snapshot of vra_block_device %s with ID: %s", blockDeviceID, snapshotID)
+	apiClient := m.(*Client).apiClient
+
+	deleteDiskSnapshotAccepted, deleteDiskSnapshotCompleted, err := apiClient.Disk.
+		DeleteFirstClassDiskSnapshot(
+			disk.NewDeleteFirstClassDiskSnapshotParams().WithID(blockDeviceID).WithId1(snapshotID))
+	if err != nil {
+		return err
+	}
+
+	// Handle non-request tracker case
+	if deleteDiskSnapshotCompleted != nil {
+		d.SetId("")
+		return nil
+	}
+
+	stateChangeFunc := resource.StateChangeConf{
+		Delay:      5 * time.Second,
+		Pending:    []string{models.RequestTrackerStatusINPROGRESS},
+		Refresh:    BlockDeviceSnapshotStateRefreshFunc(*apiClient, *deleteDiskSnapshotAccepted.Payload.ID),
+		Target:     []string{models.RequestTrackerStatusFINISHED},
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		MinTimeout: 5 * time.Second,
+	}
+
+	_, err = stateChangeFunc.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	log.Printf("Finished deleting the vra_block_device_snapshot resource with name %s", d.Get("name"))
+	return nil
+}

--- a/vra/resource_block_device_snapshot_test.go
+++ b/vra/resource_block_device_snapshot_test.go
@@ -132,6 +132,7 @@ func testAccCheckVRABlockDeviceBasicConfig(rInt int) string {
 	  project_id = data.vra_project.this.id
       depends_on = [vra_storage_profile.this]
       persistent = true
+      purge = true
 	
 	  constraints {
 		mandatory  = true

--- a/vra/resource_block_device_snapshot_test.go
+++ b/vra/resource_block_device_snapshot_test.go
@@ -1,0 +1,142 @@
+package vra
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/vmware/vra-sdk-go/pkg/client/disk"
+)
+
+func TestAccVRABlockDeviceSnapshotBasic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckBlockDeviceSnapshotResource(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRABlockDeviceSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRABlockDeviceSnapshotConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVRABlockDeviceSnapshotExists("vra_block_device_snapshot.this"),
+					resource.TestCheckResourceAttr(
+						"vra_block_device_snapshot.this", "description", "terraform block device snapshot"),
+					resource.TestCheckResourceAttrSet(
+						"vra_block_device_snapshot.this", "is_current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVRABlockDeviceSnapshotExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no block_device_snapshot ID is set")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckVRABlockDeviceSnapshotDestroy(s *terraform.State) error {
+	apiClient := testAccProviderVRA.Meta().(*Client).apiClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "vra_block_device" {
+			_, err := apiClient.Disk.GetBlockDevice(disk.NewGetBlockDeviceParams().WithID(rs.Primary.ID))
+			if err == nil {
+				return fmt.Errorf("Resource 'vra_block_device' still exists with id %s", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVRABlockDeviceSnapshotConfig(rInt int) string {
+	return testAccCheckVRABlockDeviceBasicConfig(rInt) + `
+	resource "vra_block_device_snapshot" "this" {
+	  block_device_id = vra_block_device.disk1.id
+	  description = "terraform block device snapshot"
+	}`
+}
+
+func testAccCheckVRABlockDeviceBasicConfig(rInt int) string {
+	// Need valid credentials since this is creating a real cloud account
+	name := os.Getenv("VRA_VSPHERE_CLOUD_ACCOUNT_NAME")
+	region := os.Getenv("VRA_REGION")
+	projectName := os.Getenv("VRA_PROJECT")
+	datastoreName := os.Getenv("VRA_VSPHERE_DATASTORE_NAME")
+	storagePolicyName := os.Getenv("VRA_VSPHERE_STORAGE_POLICY_NAME")
+
+	return fmt.Sprintf(`
+	data "vra_cloud_account_vsphere" "this" {
+		name = "%s"
+	  }
+
+	data "vra_region" "this" {
+		cloud_account_id = data.vra_cloud_account_vsphere.this.id
+		region = "%s"
+	}
+	
+	data "vra_project" "this" {
+		name = "%s"
+	 }
+
+	# Lookup vSphere fabric datastore using its name
+	data "vra_fabric_datastore_vsphere" "this" {
+	  filter = "name eq '%s' and cloudAccountId eq '${data.vra_cloud_account_vsphere.this.id}'"
+	}
+	
+	# Lookup vSphere fabric storage policy using its name
+	data "vra_fabric_storage_policy_vsphere" "this" {
+	  filter = "name eq '%s' and cloudAccountId eq '${data.vra_cloud_account_vsphere.this.id}'"
+	}
+	
+	resource "vra_storage_profile" "this" {
+	  name         = "vSphere-first-class-disk"
+	  description  = "vSphere Storage Profile with first class disk."
+	  region_id    = data.vra_region.this.id
+	  default_item = true
+	
+	  disk_properties = {
+		diskType         = "firstClass"
+		provisioningType = "thin" // Supported values: "thin", "thick", "eagerZeroedThick"
+	  }
+	
+	  disk_target_properties = {
+		datastoreId     = data.vra_fabric_datastore_vsphere.this.id
+		storagePolicyId = data.vra_fabric_storage_policy_vsphere.this.id
+	  }
+	
+	  tags {
+		key   = "foo"
+		value = "bar"
+	  }
+	}
+
+	resource "vra_block_device" "disk1" {
+	  capacity_in_gb = 10
+      name = "block-device-%d"
+      description = "terraform block device for snapshot"
+	  project_id = data.vra_project.this.id
+      depends_on = [vra_storage_profile.this]
+      persistent = true
+	
+	  constraints {
+		mandatory  = true
+		expression = "foo:bar"
+	  }
+	}
+`, name, region, projectName, datastoreName, storagePolicyName, rInt)
+}


### PR DESCRIPTION
Only vSphere first class disk is supported to create snapshots
Added unit tests for both resource and data source, also added examples

Update the block device snapshot is not supported