### PR TITLE
updates for new content source options

### DIFF
--- a/vra/resource_content_source.go
+++ b/vra/resource_content_source.go
@@ -31,7 +31,7 @@ func resourceContentSource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"com.gitlab", "com.github", "com.vmware.marketplace"}, true),
+				ValidateFunc: validation.StringInSlice([]string{"com.gitlab", "com.github", "com.vmware.marketplace", "org.bitbucket"}, true),
 			},
 			"project_id": {
 				Type:     schema.TypeString,
@@ -95,7 +95,7 @@ func resourceContentSource() *schema.Resource {
 						"content_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"BLUEPRINT", "IMAGE", "ABX_SCRIPTS"}, true),
+							ValidateFunc: validation.StringInSlice([]string{"BLUEPRINT", "IMAGE", "ABX_SCRIPTS", "TERRAFORM_CONFIGURATION"}, true),
 						},
 						"project_name": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
Addresses #250 Minor changes to vra_content_source to add support for bitbucket as a new repo source and ```TERRAFORM_CONFIGURATION``` as a new content type to go along with ABX_SCRIPTS,BLUEPRINT and IMAGE 

Signed-off-by: Carlos Tronco <cars@lostroncos.org>