### PR TITLE
Include snapshots info for first class disk block-devices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/go-openapi/runtime v0.19.15
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
-	github.com/vmware/vra-sdk-go v0.2.15
+	github.com/vmware/vra-sdk-go v0.2.16
 )

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/vra-sdk-go v0.2.15 h1:iTYBTDd51Ko0ZUIl0zG1uWNoaOTwefj5Z2v7ysyFO54=
-github.com/vmware/vra-sdk-go v0.2.15/go.mod h1:W6OERth9ssa4FgvS98SOVusGgBNWJs+D4Hq/5ueTgIQ=
+github.com/vmware/vra-sdk-go v0.2.16 h1:Pd4fH0N8ctUZ4yz/AcIM8qFGX2xXoL9s7pZXsw/Rz9s=
+github.com/vmware/vra-sdk-go v0.2.16/go.mod h1:W6OERth9ssa4FgvS98SOVusGgBNWJs+D4Hq/5ueTgIQ=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=

--- a/vra/data_source_block_device.go
+++ b/vra/data_source_block_device.go
@@ -15,18 +15,10 @@ func dataSourceBlockDevice() *schema.Resource {
 		Read: dataSourceBlockDeviceRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"filter": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"capacity_in_gb": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Capacity of the block device in GB.",
 			},
 			"cloud_account_ids": {
 				Type:     schema.TypeList,
@@ -34,64 +26,98 @@ func dataSourceBlockDevice() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				Description: "Id of the cloud account this storage profile belongs to.",
 			},
 			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the entity was created. The date is in ISO 8601 and UTC.",
 			},
 			"custom_properties": {
-				Type:     schema.TypeMap,
-				Computed: true,
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "\"Additional custom properties that may be used to extend the block device.",
 			},
 			"deployment_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the deployment that is associated with this resource.",
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A human-friendly description.",
+			},
+			"expand_snapshots": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether the snapshots of the block-devices should be included in the state. Applicable only for first class block devices.",
 			},
 			"external_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "External entity id on the cloud provider side.",
 			},
 			"external_region_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The external regionId of the resource.",
 			},
 			"external_zone_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The external zoneId of the resource.",
+			},
+			"filter": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+				Description:   "Search criteria to filter the list of block devices.",
+			},
+			"id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"filter"},
+				Description:   "The id of the block device.",
 			},
 			"links": linksSchema(),
 			"name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A human-friendly name for the block device.",
 			},
 			"org_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the organization this block device belongs to.",
 			},
 			"owner": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Email of the user that owns this block device.",
 			},
 			"persistent": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether the block device survives a delete action.",
 			},
 			"project_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the project this resource belongs to.",
 			},
+			"snapshots": snapshotsSchema(),
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Status of the block device.",
 			},
 			"tags": tagsSchema(),
 			"updated_at": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the entity was last updated. The date is ISO 8601 and UTC.",
 			},
 		},
 	}
@@ -158,6 +184,18 @@ func dataSourceBlockDeviceRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("links", flattenLinks(blockDevice.Links)); err != nil {
 		return fmt.Errorf("error setting block device links - error: %#v", err)
+	}
+
+	expandSnapshots := d.Get("expand_snapshots").(bool)
+	if expandSnapshots {
+		snapshots, err := apiClient.Disk.GetDiskSnapshots(disk.NewGetDiskSnapshotsParams().WithID(d.Id()))
+		if err != nil {
+			return fmt.Errorf("error getting block device snapshots - error: %#v", err)
+		}
+
+		if err := d.Set("snapshots", flattenSnapshots(snapshots.Payload)); err != nil {
+			return fmt.Errorf("error setting block device snapshots - error: %#v", err)
+		}
 	}
 
 	log.Printf("Finished reading the vra_block_device data source with filter %s", d.Get("filter"))

--- a/vra/data_source_block_device.go
+++ b/vra/data_source_block_device.go
@@ -15,6 +15,22 @@ func dataSourceBlockDevice() *schema.Resource {
 		Read: dataSourceBlockDeviceRead,
 
 		Schema: map[string]*schema.Schema{
+			// Optional arguments
+			"filter": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"id"},
+				Description:   "Search criteria to filter the list of block devices.",
+			},
+			"id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"filter"},
+				Description:   "The id of the block device.",
+			},
+
+			// Imported attributes
 			"capacity_in_gb": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -67,19 +83,6 @@ func dataSourceBlockDevice() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The external zoneId of the resource.",
-			},
-			"filter": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"id"},
-				Description:   "Search criteria to filter the list of block devices.",
-			},
-			"id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"filter"},
-				Description:   "The id of the block device.",
 			},
 			"links": linksSchema(),
 			"name": {

--- a/vra/data_source_storage_profile.go
+++ b/vra/data_source_storage_profile.go
@@ -50,7 +50,7 @@ func dataSourceStorageProfile() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"id"},
-				Description:   "Search criteria to filter the list of fabric networks.",
+				Description:   "Search criteria to filter the list of storage profiles.",
 			},
 			"id": {
 				Type:          schema.TypeString,

--- a/vra/resource_block_device.go
+++ b/vra/resource_block_device.go
@@ -26,17 +26,28 @@ func resourceBlockDevice() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			// Required arguments
 			"capacity_in_gb": {
 				Type:        schema.TypeInt,
 				Required:    true,
 				Description: "Capacity of the block device in GB.",
 			},
-			"constraints": constraintsSchema(),
-			"created_at": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Date when the entity was created. The date is in ISO 8601 and UTC.",
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return !strings.HasPrefix(new, old)
+				},
+				Description: "A human-friendly name for the block device.",
 			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The id of the project this resource belongs to.",
+			},
+
+			// Optional arguments
+			"constraints": constraintsSchema(),
 			"custom_properties": {
 				Type:        schema.TypeMap,
 				Computed:    true,
@@ -64,6 +75,28 @@ func resourceBlockDevice() *schema.Resource {
 				Optional:    true,
 				Description: "Indicates whether the block device should be encrypted or not.",
 			},
+			"expand_snapshots": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether the snapshots of the block-devices should be included in the resource state. Applicable only for first class block devices.",
+			},
+			"persistent": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Indicates whether the block device survives a delete action.",
+			},
+			"source_reference": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Reference to URI using which the block device has to be created. Example: ami-0d4cfd66",
+			},
+
+			// Imported attributes
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the entity was created. The date is in ISO 8601 and UTC.",
+			},
 			"external_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -79,20 +112,7 @@ func resourceBlockDevice() *schema.Resource {
 				Computed:    true,
 				Description: "The external zoneId of the resource.",
 			},
-			"expand_snapshots": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Indicates whether the snapshots of the block-devices should be included in the resource state. Applicable only for first class block devices.",
-			},
 			"links": linksSchema(),
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return !strings.HasPrefix(new, old)
-				},
-				Description: "A human-friendly name for the block device.",
-			},
 			"org_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -103,22 +123,7 @@ func resourceBlockDevice() *schema.Resource {
 				Computed:    true,
 				Description: "Email of the user that owns this block device.",
 			},
-			"persistent": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Indicates whether the block device survives a delete action.",
-			},
-			"project_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The id of the project this resource belongs to.",
-			},
 			"snapshots": snapshotsSchema(),
-			"source_reference": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Reference to URI using which the block device has to be created. Example: ami-0d4cfd66",
-			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/vra/resource_storage_profile.go
+++ b/vra/resource_storage_profile.go
@@ -199,7 +199,12 @@ func resourceStorageProfileDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
 	_, err := apiClient.StorageProfile.DeleteStorageProfile(storage_profile.NewDeleteStorageProfileParams().WithID(id))
 	if err != nil {
-		return err
+		switch err.(type) {
+		case *storage_profile.GetStorageProfileNotFound:
+			log.Printf("vra_storage_profile resource with id '%s' is not found", d.Get("name"))
+		default:
+			return err
+		}
 	}
 
 	d.SetId("")

--- a/vra/snapshots.go
+++ b/vra/snapshots.go
@@ -1,0 +1,85 @@
+package vra
+
+import (
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// snapshotsSchema returns the schema to use for the snapshots property
+func snapshotsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"created_at": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Date when the block-device snapshot was created. The date is in ISO 8601 and UTC.",
+				},
+				"description": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "A human-friendly description.",
+				},
+				"id": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The id of this block-device snapshot.",
+				},
+				"is_current": {
+					Type:        schema.TypeBool,
+					Computed:    true,
+					Description: "Indicates whether this snapshot is the current snapshot on the block-device.",
+				},
+				"links": linksSchema(),
+				"name": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "A human-friendly name for the block-device snapshot.",
+				},
+				"org_id": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The id of the organization this block-device snapshot belongs to.",
+				},
+				"owner": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Email of the user user that owns the block-device snapshot.",
+				},
+				"updated_at": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Date when the entity was last updated. The date is in ISO 8601 and UTC.",
+				},
+			},
+		},
+	}
+}
+
+func flattenSnapshots(diskSnapshots []*models.DiskSnapshot) []map[string]interface{} {
+	if len(diskSnapshots) == 0 {
+		return make([]map[string]interface{}, 0)
+	}
+
+	snapshots := make([]map[string]interface{}, 0, len(diskSnapshots))
+
+	for _, diskSnapshot := range diskSnapshots {
+		helper := make(map[string]interface{})
+
+		helper["created_at"] = diskSnapshot.CreatedAt
+		helper["description"] = diskSnapshot.Desc
+		helper["name"] = diskSnapshot.Name
+		helper["id"] = diskSnapshot.ID
+		helper["is_current"] = diskSnapshot.IsCurrent
+		helper["org_id"] = diskSnapshot.OrgID
+		helper["owner"] = diskSnapshot.Owner
+		helper["updated_at"] = diskSnapshot.UpdatedAt
+		helper["links"] = flattenLinks(diskSnapshot.Links)
+		snapshots = append(snapshots, helper)
+	}
+
+	return snapshots
+}


### PR DESCRIPTION
Retrieve and include the snapshots information into the state file for 
block-device resource and data sources by setting `expand_snapshots`
to true in `vra_block_device` resource and data sources.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>