### PR TITLE
Add support for deployment request inputs of array and object types

### DIFF
--- a/examples/deployment/blueprint/main.tf
+++ b/examples/deployment/blueprint/main.tf
@@ -22,8 +22,10 @@ resource "vra_deployment" "this" {
   inputs = {
     flavor = "small"
     image  = "centos"
-    count  = 2
+    count  = 1
     flag   = true
+    arrayProp = jsonencode(["foo", "bar", "baz"])
+    objectProp = jsonencode({ "key": "value", "key2": [1, 2, 3] })
   }
 
   timeouts {

--- a/examples/deployment/catalog_item/main.tf
+++ b/examples/deployment/catalog_item/main.tf
@@ -26,6 +26,9 @@ resource "vra_deployment" "this" {
     image  = "centos"
     count  = 1
     flag   = false
+    number = 10.0
+    arrayProp = jsonencode(["foo", "bar", "where", "waldo"])
+    objectProp = jsonencode({ "key1": "value1", "key2": [1, 2, 3, 4] })
   }
 
   timeouts {

--- a/vra/deployment_request.go
+++ b/vra/deployment_request.go
@@ -151,7 +151,7 @@ func flattenDeploymentRequest(deploymentRequest *models.DeploymentRequest) inter
 	helper["dismissed"] = deploymentRequest.Dismissed
 	helper["id"] = deploymentRequest.ID.String()
 	helper["initialized_at"] = deploymentRequest.InitializedAt.String()
-	helper["inputs"] = expandInputs(deploymentRequest.Inputs)
+	helper["inputs"] = expandInputsToString(deploymentRequest.Inputs)
 	helper["name"] = deploymentRequest.Name
 	helper["parent_id"] = deploymentRequest.ParentID.String()
 	helper["requested_by"] = deploymentRequest.RequestedBy

--- a/vra/structure.go
+++ b/vra/structure.go
@@ -54,6 +54,24 @@ func compareUnique(s []interface{}) bool {
 	return j == len(s)
 }
 
+////diff returns the elements in 's1' that are not in 's2'
+//func diff(s1, s2 []interface{}) []interface{} {
+//	m2 := make(map[string]struct{}, len(s2))
+//
+//	for _, v := range s2 {
+//		m2[v.(string)] = struct{}{}
+//	}
+//
+//	var diff []interface{}
+//	for _, v := range s1 {
+//		if _, found := m2[v.(string)]; !found {
+//			diff = append(diff, v)
+//		}
+//	}
+//
+//	return diff
+//}
+
 // indexOf will lookup and return the index of value in the list of items
 func indexOf(value string, items []string) (int, error) {
 	for i, v := range items {
@@ -149,13 +167,30 @@ func flattenAndNormalizeCLoudAccountGcpRegionIds(regionOrder []string, cloudAcco
 	return m, nil
 }
 
-// expandInputs will convert the interface  into a map of interface
+// expandInputs will convert the interface  into a map of [string:interface]
 func expandInputs(configInputs interface{}) map[string]interface{} {
 	if configInputs == nil {
 		return nil
 	}
 
 	inputs := make(map[string]interface{})
+	for key, value := range configInputs.(map[string]interface{}) {
+		if value != nil {
+			//inputs[key] = fmt.Sprint(value)
+			inputs[key] = value
+		}
+	}
+
+	return inputs
+}
+
+// expandInputsToString will convert the interface  into a map of string:string
+func expandInputsToString(configInputs interface{}) map[string]string {
+	if configInputs == nil {
+		return nil
+	}
+
+	inputs := make(map[string]string)
 	for key, value := range configInputs.(map[string]interface{}) {
 		if value != nil {
 			inputs[key] = fmt.Sprint(value)

--- a/vra/structure.go
+++ b/vra/structure.go
@@ -54,24 +54,6 @@ func compareUnique(s []interface{}) bool {
 	return j == len(s)
 }
 
-////diff returns the elements in 's1' that are not in 's2'
-//func diff(s1, s2 []interface{}) []interface{} {
-//	m2 := make(map[string]struct{}, len(s2))
-//
-//	for _, v := range s2 {
-//		m2[v.(string)] = struct{}{}
-//	}
-//
-//	var diff []interface{}
-//	for _, v := range s1 {
-//		if _, found := m2[v.(string)]; !found {
-//			diff = append(diff, v)
-//		}
-//	}
-//
-//	return diff
-//}
-
 // indexOf will lookup and return the index of value in the list of items
 func indexOf(value string, items []string) (int, error) {
 	for i, v := range items {

--- a/vra/structure_test.go
+++ b/vra/structure_test.go
@@ -1,7 +1,6 @@
 package vra
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -22,7 +21,7 @@ func TestExpandInputs(t *testing.T) {
 
 	expandedInputs := expandInputs(inputs)
 
-	if expandedInputs["whole"] != fmt.Sprint(2) {
+	if expandedInputs["whole"] != 2 {
 		t.Errorf("int type input is not expanded correctly.")
 	}
 
@@ -30,15 +29,15 @@ func TestExpandInputs(t *testing.T) {
 		t.Errorf("string type input is not expanded correctly.")
 	}
 
-	if expandedInputs["flag"] != fmt.Sprint(true) {
+	if expandedInputs["flag"] != true {
 		t.Errorf("bool type input is not expanded correctly.")
 	}
 
-	if expandedInputs["fraction"] != "2.4" {
+	if expandedInputs["fraction"] != 2.4 {
 		t.Errorf("float type input is not expanded correctly.")
 	}
 
-	if expandedInputs["message"] != fmt.Sprint(m) {
-		t.Errorf("float type input is not expanded correctly.")
+	if expandedInputs["message"] != m {
+		t.Errorf("object type input is not expanded correctly.")
 	}
 }


### PR DESCRIPTION
This commit adds the support for  of array and object types in `vra_deployment` resource.

By default, all `TypeMap` properties in resource schema supports only primitive types and the values should be of type `string`  even when the `Elem` property is not specified. This is the same behavior even with terraform-plugin-sdk v2.

Hence, the inputs of 'array' and 'object' types from vRA cloud templates in `vra_deployment` resource should be provided in string format in Terraform configuration files.

Here's an example on how the inputs of different types can be specified in configuration file:

```
inputs = {
    StringInput  = small
    integerInput = 1
    booleanInput = false
    numberInput  = 10.0
    arrayInput   = jsonencode([foo, bar, where, waldo])
    objectInput  = jsonencode({ key1 : value1, key2 : [1, 2, 3, 4] })
}
```

The state includes `inputs` and `inputs_including_defaults`, out of which `inputs` are only those that are included in configuration file and `inputs_including_defaults` are both those from the configuration file and any inputs omitted from configuration file but have defaults defined in cloud templates.

Fixes #205.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>