### PR TITLE
Allow vra_machine creation with first class vSphere disks

### DIFF
--- a/vra/provider.go
+++ b/vra/provider.go
@@ -101,7 +101,7 @@ func Provider() *schema.Provider {
 			"vra_cloud_account_vsphere":      resourceCloudAccountVsphere(),
 			"vra_content_source":             resourceContentSource(),
 			"vra_deployment":                 resourceDeployment(),
-			"vra_fabric_network_vsphere":     resourceVsphereFabricNetwork(),
+			"vra_fabric_network_vsphere":     resourceFabricNetworkVsphere(),
 			"vra_flavor_profile":             resourceFlavorProfile(),
 			"vra_image_profile":              resourceImageProfile(),
 			"vra_load_balancer":              resourceLoadBalancer(),

--- a/vra/resource_fabric_network_vsphere.go
+++ b/vra/resource_fabric_network_vsphere.go
@@ -11,12 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func resourceVsphereFabricNetwork() *schema.Resource {
+func resourceFabricNetworkVsphere() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVsphereFabricNetworkCreate,
-		Read:   resourceVsphereFabricNetworkRead,
-		Update: resourceVsphereFabricNetworkUpdate,
-		Delete: resourceVsphereFabricNetworkDelete,
+		Create: resourceFabricNetworkVsphereCreate,
+		Read:   resourceFabricNetworkVsphereRead,
+		Update: resourceFabricNetworkVsphereUpdate,
+		Delete: resourceFabricNetworkVsphereDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -113,12 +113,12 @@ func resourceVsphereFabricNetwork() *schema.Resource {
 	}
 }
 
-func resourceVsphereFabricNetworkCreate(d *schema.ResourceData, m interface{}) error {
+func resourceFabricNetworkVsphereCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("Starting to create vra_fabric_network resource")
-	return errors.New("vra_fabric_network resources are only importable")
+	return errors.New("vra_fabric_network_vsphere resources are only importable")
 }
 
-func resourceVsphereFabricNetworkRead(d *schema.ResourceData, m interface{}) error {
+func resourceFabricNetworkVsphereRead(d *schema.ResourceData, m interface{}) error {
 	log.Printf("Reading the vra_fabric_network_vsphere resource with name %s", d.Get("name"))
 	apiClient := m.(*Client).apiClient
 
@@ -158,7 +158,7 @@ func resourceVsphereFabricNetworkRead(d *schema.ResourceData, m interface{}) err
 	return nil
 }
 
-func resourceVsphereFabricNetworkUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceFabricNetworkVsphereUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("Starting to Update vra_fabric_network resource")
 	var dnsSearchDomains []string
 	var dnsServerAddresses []string
@@ -200,11 +200,11 @@ func resourceVsphereFabricNetworkUpdate(d *schema.ResourceData, m interface{}) e
 		return err
 	}
 	log.Printf("finished Updating vra_fabric_network_vsphere resource")
-	return resourceVsphereFabricNetworkRead(d, m)
+	return resourceFabricNetworkVsphereRead(d, m)
 
 }
 
-func resourceVsphereFabricNetworkDelete(d *schema.ResourceData, m interface{}) error {
+func resourceFabricNetworkVsphereDelete(d *schema.ResourceData, m interface{}) error {
 	log.Printf("Starting to delete the vra_fabric_network_vsphere resource with name %s", d.Get("name"))
 	return nil
 }

--- a/vra/resource_fabric_network_vsphere_test.go
+++ b/vra/resource_fabric_network_vsphere_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccVRAFabricNetworkVsphere_importBasic(t *testing.T) {
 	resourceName := "vra_fabric_network_vsphere.this"
 	fabricNetworkID := os.Getenv("VRA_FABRIC_NETWORK_VSPHERE_ID")
-	createErrorRegex := regexp.MustCompile("vra_fabric_network resources are only importable")
+	createErrorRegex := regexp.MustCompile("vra_fabric_network_vsphere resources are only importable")
 
 	checkFn := func(s []*terraform.InstanceState) error {
 		if len(s) != 1 {


### PR DESCRIPTION
Due to limitations to attach a first class vSphere disk to a machine during
provisioning as day-0 operation, the vra_machine resource create operation is
now changed to create the machine first without disks (even if given in the
configuration file) and then the disks are attached one by one as day-2 actions.

Also, the file name for vra_fabric_network_vsphere resource is modified to be
in consistent with other file names.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>