### PR TITLE
Fix provider validation error in vra_zone resource

### DIFF
--- a/vra/resource_image_profile.go
+++ b/vra/resource_image_profile.go
@@ -27,7 +27,7 @@ func resourceImageProfile() *schema.Resource {
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Computed:    true,
+				Optional:    true,
 				Description: "A human-friendly description.",
 			},
 			"external_region_id": {

--- a/vra/resource_zone.go
+++ b/vra/resource_zone.go
@@ -36,7 +36,7 @@ func resourceZone() *schema.Resource {
 			},
 			"placement_policy": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				Default:  "DEFAULT",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)

--- a/website/docs/r/vra_zone.html.markdown
+++ b/website/docs/r/vra_zone.html.markdown
@@ -38,7 +38,7 @@ A zone profile resource supports the following arguments:
 
 * `name` - (Required) A human-friendly name used as an identifier in APIs that support this option.
 
-* `placement_policy` - (Required) The id of the region for which this zone is defined
+* `placement_policy` - (Optional) The id of the region for which this zone is defined. Valid values are: `DEFAULT`, `SPREAD`, `BINPACK`. Default is `DEFAULT`.
 
 * `region_id` - (Required) A link to the region that is associated with the storage profile.                      example:[ { "key" : "ownedBy", "value": "Rainpole" } ]
 


### PR DESCRIPTION
With the latest SDK updates, an argument in a schema cannot have both Required and Default schema attributes.

This commit makes the 'placement_policy' in 'vra_zone' resource as optional as it has a default value.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>