### PR TITLE
Fix misisng fields while importing resources

### DIFF
--- a/examples/cloud_account_vsphere/main.tf
+++ b/examples/cloud_account_vsphere/main.tf
@@ -4,7 +4,7 @@ provider "vra" {
   insecure      = var.insecure // false for vRA Cloud and true for vRA 8.0
 }
 
-// Required for vRA Cloud, Optional for vRA 8.X
+ Required for vRA Cloud, Optional for vRA 8.X
 data "vra_data_collector" "dc" {
   count = var.datacollector != "" ? 1 : 0
   name  = var.datacollector

--- a/examples/flavor_profile/main.tf
+++ b/examples/flavor_profile/main.tf
@@ -1,0 +1,29 @@
+provider "vra" {
+  url           = var.url
+  refresh_token = var.refresh_token
+}
+
+data "vra_cloud_account_aws" "this" {
+  name = var.cloud_account
+}
+
+data "vra_region" "this" {
+  cloud_account_id = data.vra_cloud_account_aws.this.id
+  region           = var.region
+}
+
+resource "vra_flavor_profile" "this" {
+  name        = "tf-vra-flavor-profile"
+  description = "my flavor"
+  region_id   = data.vra_region.this.id
+
+  flavor_mapping {
+    name          = "small"
+    instance_type = "t2.small"
+  }
+
+  flavor_mapping {
+    name          = "medium"
+    instance_type = "t2.medium"
+  }
+}

--- a/examples/flavor_profile/variables.tf
+++ b/examples/flavor_profile/variables.tf
@@ -1,0 +1,11 @@
+variable "refresh_token" {
+}
+
+variable "url" {
+}
+
+variable "cloud_account" {
+}
+
+variable "region" {
+}

--- a/examples/flavor_profile/versions.tf
+++ b/examples/flavor_profile/versions.tf
@@ -1,9 +1,8 @@
-
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     vra = {
       source = "vmware/vra"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/examples/network_profile/simple/versions.tf
+++ b/examples/network_profile/simple/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    vra = {
+      source = "vmware/vra"
+    }
+  }
 }

--- a/examples/zone/versions.tf
+++ b/examples/zone/versions.tf
@@ -1,9 +1,8 @@
-
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     vra = {
       source = "vmware/vra"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/vra/resource_cloud_account_vsphere.go
+++ b/vra/resource_cloud_account_vsphere.go
@@ -72,6 +72,10 @@ func resourceCloudAccountVsphere() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"custom_properties": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 			"links": linksSchema(),
 			"org_id": {
 				Type:     schema.TypeString,
@@ -171,8 +175,10 @@ func resourceCloudAccountVsphereRead(d *schema.ResourceData, m interface{}) erro
 
 	d.Set("associated_cloud_account_ids", flattenAssociatedCloudAccountIds(vsphereAccount.Links))
 	d.Set("created_at", vsphereAccount.CreatedAt)
+	d.Set("custom_properties", vsphereAccount.CustomProperties)
 	d.Set("dcid", vsphereAccount.Dcid)
 	d.Set("description", vsphereAccount.Description)
+	d.Set("hostname", vsphereAccount.HostName)
 	d.Set("name", vsphereAccount.Name)
 	d.Set("org_id", vsphereAccount.OrgID)
 	d.Set("owner", vsphereAccount.Owner)

--- a/vra/resource_storage_profile.go
+++ b/vra/resource_storage_profile.go
@@ -138,6 +138,7 @@ func resourceStorageProfileRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	storageProfile := *resp.Payload
+	d.Set("cloud_account_id", storageProfile.CloudAccountID)
 	d.Set("created_at", storageProfile.CreatedAt)
 	d.Set("default_item", storageProfile.DefaultItem)
 	d.Set("description", storageProfile.Description)

--- a/vra/resource_zone.go
+++ b/vra/resource_zone.go
@@ -19,20 +19,46 @@ func resourceZone() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"cloud_account_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the cloud account this zone belongs to.",
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"custom_properties": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A human-friendly description for the zone",
+			},
+			"external_region_id": {
+				Type:     schema.TypeMap,
+				Computed: true,
 			},
 			"folder": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The folder relative path to the datacenter where resources are deployed to. (only applicable for vSphere cloud zones)",
 			},
+			"links": linksSchema(),
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "A human-friendly name for the zone",
+			},
+			"org_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"placement_policy": {
 				Type:     schema.TypeString,
@@ -55,6 +81,10 @@ func resourceZone() *schema.Resource {
 			},
 			"tags":          tagsSchema(),
 			"tags_to_match": tagsSchema(),
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -108,8 +138,20 @@ func resourceZoneRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	zone := *ret.Payload
+	d.Set("cloud_account_id", zone.CloudAccountID)
+	d.Set("created_at", zone.CreatedAt)
+	d.Set("custom_properties", zone.CustomProperties)
 	d.Set("description", zone.Description)
+	d.Set("external_region_id", zone.ExternalRegionID)
+	d.Set("folder", zone.Folder)
+
+	if err := d.Set("links", flattenLinks(zone.Links)); err != nil {
+		return fmt.Errorf("error setting zone links - error: %#v", err)
+	}
+
 	d.Set("name", zone.Name)
+	d.Set("org_id", zone.OrgID)
+	d.Set("owner", zone.Owner)
 	d.Set("placement_policy", zone.PlacementPolicy)
 	if err := d.Set("tags", flattenTags(zone.Tags)); err != nil {
 		return fmt.Errorf("Error setting zone tags - error: %#v", err)
@@ -117,6 +159,7 @@ func resourceZoneRead(d *schema.ResourceData, m interface{}) error {
 	if err := d.Set("tags_to_match", flattenTags(zone.TagsToMatch)); err != nil {
 		return fmt.Errorf("Error setting zone tags_to_match - error: %#v", err)
 	}
+	d.Set("updated_at", zone.UpdatedAt)
 	return nil
 }
 

--- a/website/docs/r/cloud_account_vsphere.html.markdown
+++ b/website/docs/r/cloud_account_vsphere.html.markdown
@@ -62,6 +62,8 @@ Example:[ { "key" : "vmware", "value": "provider" } ]
 
 * `created_at` - Date when  entity was created. Date and time format is ISO 8601 and UTC.
 
+* `custom_properties` - A list of key value pair of properties associated with this cloud account.
+
 * `id` - (Optional) ID of the vSphere cloud account.
 
 * `links` - HATEOAS of entity.

--- a/website/docs/r/vra_flavor_profile.html.markdown
+++ b/website/docs/r/vra_flavor_profile.html.markdown
@@ -38,3 +38,19 @@ An flavor profile resource supports the following arguments:
 * `region_id` - (Required) The id of the region for which this profile is defined as in vRealize Automation(vRA).
 
 * `flavor_mapping` - (Optional) Map between global fabric flavor keys and fabric flavor descriptions.
+
+## Attribute Reference
+
+* * `cloud_account_id` - The ID of the cloud account this flavor profile belongs to.
+
+* `created_at` - Date when  entity was created. Date and time format is ISO 8601 and UTC.
+
+* `external_region_id` - The ID of the external region that is associated with the flavor profile.
+
+* `links` - HATEOAS of entity.
+
+* `org_id` - ID of organization that entity belongs to.
+
+* `owner` - Email of entity owner.
+
+* `updated_at` - Date when the entity was last updated. Date and time format is ISO 8601 and UTC.

--- a/website/docs/r/vra_network_profile.html.markdown
+++ b/website/docs/r/vra_network_profile.html.markdown
@@ -50,6 +50,10 @@ A network profile resource supports the following arguments:
 
 ## Attributes Reference
 
+* * `cloud_account_id` - The ID of the cloud account this flavor profile belongs to.
+
+* `created_at` - Date when  entity was created. Date and time format is ISO 8601 and UTC.
+
 * `external_region_id` - The external regionId of the resource. 
 
 * `isolated_network_cidr_prefix` - The CIDR prefix length to be used for the isolated networks that are created with the network profile.
@@ -62,7 +66,9 @@ A network profile resource supports the following arguments:
 
 * `links` - HATEOAS of the entity
 
-* `organization_id` - The id of the organization this entity belongs to.
+* `org_id` - ID of organization that entity belongs to.
+
+* `organization_id` - The id of the organization this entity belongs to. Deprecated, refer to org_id instead.
 
 * `owner` - Email of the user that owns the entity.
 

--- a/website/docs/r/vra_zone.html.markdown
+++ b/website/docs/r/vra_zone.html.markdown
@@ -40,9 +40,27 @@ A zone profile resource supports the following arguments:
 
 * `placement_policy` - (Optional) The id of the region for which this zone is defined. Valid values are: `DEFAULT`, `SPREAD`, `BINPACK`. Default is `DEFAULT`.
 
-* `region_id` - (Required) A link to the region that is associated with the storage profile.                      example:[ { "key" : "ownedBy", "value": "Rainpole" } ]
+* `region_id` - (Required) A link to the region that is associated with the zone.                      example:[ { "key" : "ownedBy", "value": "Rainpole" } ]
 
-* `tags` - (Optional) A set of tag keys and optional values that were set on this Network Profile.
+* `tags` - (Optional) A set of tag keys and optional values that were set on this zone.
 
 * `tags_to_match` - (Optional) A set of tag keys and optional values for compute resource filtering.
                    example:[ { "key" : "compliance", "value": "pci" } ]
+
+## Attribute Reference
+
+* `cloud_account_id` - The ID of the cloud account this zone belongs to.
+
+* `created_at` - Date when  entity was created. Date and time format is ISO 8601 and UTC.
+
+* `custom_properties` - A list of key value pair of properties related to the zone.
+
+* `external_region_id` - The ID of the external region that is associated with the zone.
+
+* `links` - HATEOAS of entity.
+
+* `org_id` - ID of organization that entity belongs to.
+
+* `owner` - Email of entity owner.
+
+* `updated_at` - Date when the entity was last updated. Date and time format is ISO 8601 and UTC.


### PR DESCRIPTION
This commit fixes the missing fields while the resources are imported for
resources such as vra_cloud_account_vsphere, vra_zone, vra_flavor_profile,
vra_network_profile, and vra_storage_profile.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>