### PR TITLE
[305] vra_project -> zone_assignments ignore multiple values

### DIFF
--- a/vra/data_source_project.go
+++ b/vra/data_source_project.go
@@ -89,7 +89,7 @@ func dataSourceProject() *schema.Resource {
 				},
 			},
 			"zone_assignments": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "List of configurations for zone assignment to a project.",
 				Elem: &schema.Resource{


### PR DESCRIPTION
The zone_assignments were not saved in state file when reading the project
as a data source. Fixed it by changing the type to type list from type set

Signed-off-by: Prativa Bawri <bawrip@vmware.com>