### PR TITLE
[issue-323] Importing vRA Cloud Zone doesn't import region ID

### DIFF
--- a/vra/data_source_zone.go
+++ b/vra/data_source_zone.go
@@ -46,13 +46,13 @@ func dataSourceZone() *schema.Resource {
 			},
 			"owner": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"placement_policy": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"region_id": {
+			"external_region_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -87,6 +87,7 @@ func dataSourceZoneRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("name", zone.Name)
 		d.Set("created_at", zone.CreatedAt)
 		d.Set("custom_properties", zone.CustomProperties)
+		d.Set("external_region_id", zone.ExternalRegionID)
 		d.Set("folder", zone.Folder)
 		d.Set("org_id", zone.OrgID)
 		d.Set("owner", zone.Owner)

--- a/vra/resource_zone.go
+++ b/vra/resource_zone.go
@@ -38,7 +38,7 @@ func resourceZone() *schema.Resource {
 				Description: "A human-friendly description for the zone",
 			},
 			"external_region_id": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"folder": {

--- a/website/docs/d/vra_zone.html.markdown
+++ b/website/docs/d/vra_zone.html.markdown
@@ -40,7 +40,7 @@ A zone data source supports the following arguments:
 
 * `placement_policy` - The id of the region for which this zone is defined
 
-* `region_id` - A link to the region that is associated with the storage profile.
+* `external_region_id` - The id of the region for which this zone is defined.
 
 * `shared_resources` - The id of the organization this entity belongs to.
 

--- a/website/docs/r/vra_zone.html.markdown
+++ b/website/docs/r/vra_zone.html.markdown
@@ -55,7 +55,7 @@ A zone profile resource supports the following arguments:
 
 * `custom_properties` - A list of key value pair of properties related to the zone.
 
-* `external_region_id` - The ID of the external region that is associated with the zone.
+* `external_region_id` - The id of the region for which this zone is defined.
 
 * `links` - HATEOAS of entity.
 


### PR DESCRIPTION
In GET vra_zone, there is nor region_id. The region id is called
external region id in when a zone is read.

So, when creating a zone, a region id has to be provided. In the state file, the region id
is translated to external region id

Signed-off-by: Prativa Bawri <bawrip@vmware.com>