### PR TITLE
Allow AD groups as Project users

### DIFF
--- a/examples/project/main.tf
+++ b/examples/project/main.tf
@@ -23,11 +23,44 @@ resource "vra_project" "this" {
 
   shared_resources = false
 
+  # Deprecated, please use administrator_roles instead.
   administrators = ["jason@vra.local"]
 
+  administrator_roles {
+    email = "jason@vra.local"
+    type = "user"
+  }
+
+  administrator_roles {
+    email = "jason-group@vra.local"
+    type = "group"
+  }
+
+  # Deprecated, please use member_roles instead.
   members = ["tony@vra.local"]
 
+  member_roles {
+    email = "tony@vra.local"
+    type = "user"
+  }
+
+  member_roles {
+    email = "tony-group@vra.local"
+    type = "group"
+  }
+
+  # Deprecated, please use viewer_roles instead
   viewers = ["shauna@vra.local"]
+
+  viewer_roles {
+    email = "shauna@vra.local"
+    type = "user"
+  }
+
+  viewer_roles {
+    email = "shauna-group@vra.local"
+    type = "group"
+  }
 
   operation_timeout = 6000
 

--- a/vra/data_source_project.go
+++ b/vra/data_source_project.go
@@ -23,6 +23,7 @@ func dataSourceProject() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"administrator_roles": userSchema("List of administrator roles associated with the project. Only administrators can manage project's configuration."),
 			"constraints": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -61,6 +62,7 @@ func dataSourceProject() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"member_roles": userSchema("List of member roles associated with the project."),
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -93,6 +95,7 @@ func dataSourceProject() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"viewer_roles": userSchema("List of viewer roles associated with the project."),
 			"zone_assignments": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -153,16 +156,19 @@ func dataSourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	setFields := func(project *models.Project) {
 		d.SetId(*project.ID)
-		d.Set("administrators", flattenUserList(project.Administrators))
+		d.Set("administrators", flattenUsers(project.Administrators))
+		d.Set("administrator_roles", flattenUsers(project.Administrators))
 		d.Set("constraints", flattenProjectConstraints(project.Constraints))
 		d.Set("custom_properties", project.CustomProperties)
 		d.Set("description", project.Description)
 		d.Set("machine_naming_template", project.MachineNamingTemplate)
-		d.Set("members", flattenUserList(project.Members))
+		d.Set("members", flattenUsers(project.Members))
+		d.Set("member_roles", flattenUsers(project.Members))
 		d.Set("name", project.Name)
 		d.Set("operation_timeout", project.OperationTimeout)
 		d.Set("shared_resources", project.SharedResources)
-		d.Set("viewers", flattenUserList(project.Viewers))
+		d.Set("viewers", flattenUsers(project.Viewers))
+		d.Set("viewer_roles", flattenUsers(project.Viewers))
 		d.Set("zone_assignments", flattenZoneAssignment(project.Zones))
 	}
 

--- a/vra/user.go
+++ b/vra/user.go
@@ -1,0 +1,70 @@
+package vra
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+)
+
+// userSchema returns the schema to use for the administrator / member property in Project
+func userSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:        schema.TypeString,
+					Default:     "user",
+					Optional:    true,
+					Description: "Type of the principal. Currently supported ‘user’ (default) and 'group’.",
+				},
+				"email": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "The email of the user or name of the group.",
+					Required:    true,
+				},
+			},
+		},
+	}
+}
+
+func expandUsers(configUsers []interface{}) []*models.User {
+	users := make([]*models.User, 0, len(configUsers))
+
+	for _, configUser := range configUsers {
+		userMap := configUser.(map[string]interface{})
+
+		var user models.User
+
+		if v, found := userMap["type"]; found && v != nil {
+			user.Type = v.(string)
+		}
+
+		if v, found := userMap["email"]; found && v != nil {
+			user.Email = withString(v.(string))
+		}
+
+		users = append(users, &user)
+	}
+
+	return users
+}
+
+func flattenUsers(users []*models.User) []interface{} {
+	if len(users) == 0 {
+		return make([]interface{}, 0)
+	}
+
+	configUsers := make([]interface{}, 0, len(users))
+
+	for _, user := range users {
+		helper := make(map[string]interface{})
+		helper["email"] = *user.Email
+		helper["type"] = user.Type
+
+		configUsers = append(configUsers, helper)
+	}
+
+	return configUsers
+}

--- a/vra/user.go
+++ b/vra/user.go
@@ -5,11 +5,12 @@ import (
 	"github.com/vmware/vra-sdk-go/pkg/models"
 )
 
-// userSchema returns the schema to use for the administrator / member property in Project
-func userSchema() *schema.Schema {
+// userSchema returns the schema to use for the administrator / member / viewer property in Project
+func userSchema(description string) *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
-		Optional: true,
+		Type:        schema.TypeSet,
+		Description: description,
+		Optional:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"type": {
@@ -20,7 +21,6 @@ func userSchema() *schema.Schema {
 				},
 				"email": {
 					Type:        schema.TypeString,
-					Computed:    true,
 					Description: "The email of the user or name of the group.",
 					Required:    true,
 				},

--- a/website/docs/d/vra_project.html.markdown
+++ b/website/docs/d/vra_project.html.markdown
@@ -29,7 +29,10 @@ A project data source supports the following arguments:
 
 ## Argument Reference
 
-* `administrators` - (Optional) List of administrator users associated with the project. Only administrators can manage project's configuration.
+* `administrators` - (Optional) List of administrator users associated with the project. Only administrators can manage project's configuration. 
+Deprecated, to specify the type of principal, please refer `administrator_roles`.
+
+* `administrator_roles` - (Optional) Administrator users or groups associated with the project. Only administrators can manage project's configuration. 
 
 * `constraints` - (Optional) List of storage, network and extensibility constraints to be applied when provisioning through this project.
 
@@ -41,7 +44,9 @@ A project data source supports the following arguments:
 
 * `machine_naming_template` - (Optional) The naming template to be used for resources provisioned in this project.
 
-* `members` - (Optional) List of member users associated with the project.
+* `members` - (Optional) List of member users associated with the project. Deprecated, to specify the type of principal, please refer `member_roles`.
+
+* `member_roles` - (Optional) Member users or groups associated with the project. 
 
 * `name` - (Optional) A human-friendly name used as an identifier in APIs that support this option.
 
@@ -53,4 +58,6 @@ A project data source supports the following arguments:
 
 * `shared_resources` - (Optional) The id of the organization this entity belongs to.
 
-* `viewer` - (Optional) List of viewer users associated with the project.
+* `viewers` - (Optional) List of viewer users associated with the project. Deprecated, to specify the type of principal, please refer `viewer_roles`.
+
+* `viewer_roles` - (Optional) Viewer users or groups associated with the project. 

--- a/website/docs/r/vra_project.html.markdown
+++ b/website/docs/r/vra_project.html.markdown
@@ -29,11 +29,44 @@ resource "vra_project" "this" {
   
   shared_resources = false
 
+  # Deprecated, please use administrator_roles instead.
   administrators = ["jason@vra.local"]
+  
+  administrator_roles {
+    email = "jason@vra.local"
+    type = "user"
+  }
 
+  administrator_roles {
+    email = "jason-group@vra.local"
+    type = "group"
+  }
+
+  # Deprecated, please use member_roles instead.
   members = ["tony@vra.local"]
 
+  member_roles {
+    email = "tony@vra.local"
+    type = "user"
+  }
+
+  member_roles {
+    email = "tony-group@vra.local"
+    type = "group"
+  }
+
+  # Deprecated, please use viewer_roles instead
   viewers = ["shauna@vra.local"]
+
+  viewer_roles {
+    email = "shauna@vra.local"
+    type = "user"
+  }
+
+  viewer_roles {
+    email = "shauna-group@vra.local"
+    type = "group"
+  }
 
   operation_timeout = 6000
 
@@ -74,7 +107,10 @@ A project resource supports the following arguments:
 
 ## Argument Reference
 
-* `administrators` - (Optional) List of administrator users associated with the project. Only administrators can manage project's configuration.
+* `administrators` - (Optional) List of administrator users associated with the project. Only administrators can manage project's configuration. 
+Deprecated, specify the type of principal, please refer `administrator_roles`.
+
+* `administrator_roles` - (Optional) Administrator users or groups associated with the project. Only administrators can manage project's configuration. 
 
 * `constraints` - (Optional) List of storage, network and extensibility constraints to be applied when provisioning through this project.
 
@@ -84,7 +120,9 @@ A project resource supports the following arguments:
 
 * `machine_naming_template` - (Optional) The naming template to be used for resources provisioned in this project.
 
-* `members` - (Optional) List of member users associated with the project.
+* `members` - (Optional) List of member users associated with the project. Deprecated, specify the type of principal, please refer `member_roles`.
+
+* `member_roles` - (Optional) Member users or groups associated with the project. 
 
 * `name` - (Required) A human-friendly name used as an identifier in APIs that support this option.
 
@@ -92,6 +130,8 @@ A project resource supports the following arguments:
 
 * `shared_resources` - (Optional) Specifies whether the resources in this projects are shared or not. If not set default will be used.
 
-* `viewer` - (Optional) List of viewer users associated with the project.
+* `viewers` - (Optional) List of viewer users associated with the project. Deprecated, specify the type of principal, please refer `viewer_roles`.
+
+* `viewer_roles` - (Optional) Viewer users or groups associated with the project. 
 
 * `zone_assignments` - (Optional) List of configurations for zone assignment to a project.


### PR DESCRIPTION
Fix proposal is to deprecate the existing arguments for administrators, members, and viewers
and introduce new arguments to allow both email addresses and AD groups.

Signed-off-by: Deepak Mettem <dmettem@vmware.com>