### PR TITLE
Update deprecated linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,6 +10,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.41.1
           args: --issues-exit-code=1
           only-new-issues: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.41.1
           args: --issues-exit-code=1
       -
         name: Import GPG key

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,13 +12,12 @@ linters:
     - errcheck
     # - gofmt
     - goimports
-    - golint
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - nakedret
     - misspell
+    - revive
     - staticcheck
     - structcheck
     - typecheck

--- a/vra/data_source_deployment.go
+++ b/vra/data_source_deployment.go
@@ -213,8 +213,5 @@ func dataSourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	deployment := getResp.Payload
-	if err = setFields(deployment); err != nil {
-		return err
-	}
-	return nil
+	return setFields(deployment)
 }


### PR DESCRIPTION
* Upgrade `golangci-lint` to v1.41.1
* Remove deprecated `interfacer` linter
* Replace deprecated `golint` linter with `revive`
* Fix a linter issue

Signed-off-by: Ferran Rodenas <rodenasf@vmware.com>