### PR TITLE
[Issue-347]Region data source returns null property values

### DIFF
--- a/vra/data_source_region.go
+++ b/vra/data_source_region.go
@@ -21,6 +21,7 @@ func dataSourceRegion() *schema.Resource {
 			"cloud_account_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"created_at": {
 				Type:     schema.TypeString,
@@ -41,11 +42,11 @@ func dataSourceRegion() *schema.Resource {
 			},
 			"name": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"org_id": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Computed: true,
 			},
 			"owner": {
 				Type:     schema.TypeString,
@@ -81,8 +82,9 @@ func dataSourceRegionRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("created_at", region.CreatedAt)
 		d.Set("external_region_id", region.ExternalRegionID)
 		d.Set("name", region.Name)
-		d.Set("orgId", region.OrgID)
+		d.Set("org_id", region.OrgID)
 		d.Set("owner", region.Owner)
+		d.Set("updated_at", region.UpdatedAt)
 	}
 
 	if idOk {


### PR DESCRIPTION
Fixed org_id and updated_at
Owner and created_at are missing from the API response. Opened a bug in vRA.
Once that is resolved, these two fields will be populated as well.

Signed-off-by: Prativa Bawri <bawrip@vmware.com>