### PR TITLE
Update provider's index documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,18 +1,18 @@
 ---
 layout: "vra"
-page_title: "Provider: VMware Cloud Automation Services"
+page_title: "Provider: VMware vRealize Automation Services"
 sidebar_current: "docs-vra-index"
 description: |-
-  A Terraform provider to work with VMware Cloud Automation Services.
+  A Terraform provider to work with VMware vRealize Automation Services.
 ---
 
-# VMware Cloud Automation Services Provider
+# VMware vRealize Automation Provider
 
-The VMware Cloud Automation Services provider gives Terraform the ability to work
-with [VMware Cloud Assembly][vmware-cloud-assembly]. This provider can be used to
-deploy multi-cloud infrastructure components.
+Use the VMware vRealize Automation provider to interact with resources supported by
+[VMware vRealize Automation][vmware-vrealize-automation] services. This provider can
+be used to configure multi-cloud infrastructure components to enable multi-cloud automation services.
 
-[vmware-cloud-assembly]: https://cloud.vmware.com/cloud-assembly
+[vmware-vrealize-automation]: https://www.vmware.com/products/vrealize-automation.html
 
 Use the navigation on the left to read about the various resources and data
 sources supported by the provider.
@@ -21,8 +21,6 @@ sources supported by the provider.
 
 The following abridged example demonstrates a current basic usage of the
 provider.
-
-[tf-vra7-deployment]: /docs/providers/vra7/r/deployment.html
 
 ```hcl
 provider "vra" {
@@ -36,9 +34,9 @@ examples specific to their own use cases.
 
 ## Argument Reference
 
-The following arguments are used to configure the VMware vRA7 Provider:
+The following arguments are used to configure the VMware vRealize Automation Provider:
 
-* `url` - (Required) This is the URL to the VMware Cloud Automation
+* `url` - (Required) This is the URL to the VMware vRealize Automation
   Services endpoint. Can also  be specified with the `vRA_URL` environment variable.
 * `access_token` - (Optional) This is the access token used to create an API
   refresh token. Can also be specified with the `vRA_ACCESS_TOKEN` environment variable.
@@ -46,21 +44,11 @@ The following arguments are used to configure the VMware vRA7 Provider:
   has been pre-generated. One of `access_token` or `refresh_token` is required.
   Can also be specified with the `vRA_REFRESH_TOKEN` environment variable.
 
-### Debugging options
-
-~> **NOTE:** The following options can leak sensitive data and should only be
-enabled when instructed to do so by HashiCorp for the purposes of
-troubleshooting issues with the provider, or when attempting to perform your
-own troubleshooting. Use them at your own risk and do not leave them enabled!
-
-* ***Add info here on debuggings ***
-
 ## Bug Reports and Contributing
 
 For more information how how to submit bug reports, feature requests, or
-details on how to make your own contributions to the provider, see the vRA7
-provider [project page][tf-vra7-project-page].
+details on how to make your own contributions to the provider, see the Terraform provider for VMware vRealize Automation [project page][tf-vra-project-page].
 
-[tf-vra7-project-page]: https://github.com/vmware/terraform-provider-vra7
+[tf-vra-project-page]: https://github.com/vmware/terraform-provider-vra
 
 


### PR DESCRIPTION
Update the [provider's index page](https://registry.terraform.io/providers/vmware/vra/latest/docs) to reflect the correct product name, description, and links. It also removes the `Debugging options` section.

Fixes #350 

Signed-off-by: Ferran Rodenas <rodenasf@vmware.com>