### PR TITLE
Update vRA SDKs to v0.2.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/go-openapi/runtime v0.19.16
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
-	github.com/vmware/vra-sdk-go v0.2.20
+	github.com/vmware/vra-sdk-go v0.2.21
 )

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/vra-sdk-go v0.2.20 h1:9HqOVR7VTvNRVKTzHXkvqtg0/t0CfP/th3VQ68xNT74=
-github.com/vmware/vra-sdk-go v0.2.20/go.mod h1:Ver/bWTAky1InVMlijshohgs9+N4Y+5gAJAALJWqgMw=
+github.com/vmware/vra-sdk-go v0.2.21 h1:nHioDIRebknGAa3UgcgAKFAnVk3r7EKV6QrWZZQbYkg=
+github.com/vmware/vra-sdk-go v0.2.21/go.mod h1:Ver/bWTAky1InVMlijshohgs9+N4Y+5gAJAALJWqgMw=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vra/data_source_deployment.go
+++ b/vra/data_source_deployment.go
@@ -201,7 +201,7 @@ func dataSourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 	// Get the deployment details with all the user provided flags
 	getResp, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
 		deployments.NewGetDeploymentByIDUsingGETParams().
-			WithDepID(strfmt.UUID(id.(string))).
+			WithDeploymentID(strfmt.UUID(id.(string))).
 			WithExpandProject(withBool(expandProject)).
 			WithExpandResources(withBool(expandResources)).
 			WithExpandLastRequest(withBool(expandLastRequest)).

--- a/vra/deployment_request.go
+++ b/vra/deployment_request.go
@@ -99,10 +99,13 @@ func deploymentRequestSchema() *schema.Schema {
 					Optional: true,
 					Computed: true,
 				},
-				"resource_name": {
-					Type:     schema.TypeString,
+				"resource_ids": {
+					Type:     schema.TypeList,
 					Optional: true,
 					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
 				},
 				"status": {
 					Type:     schema.TypeString,
@@ -147,7 +150,7 @@ func flattenDeploymentRequest(deploymentRequest *models.Request) interface{} {
 	helper["name"] = deploymentRequest.Name
 	helper["outputs"] = expandInputsToString(deploymentRequest.Outputs)
 	helper["requested_by"] = deploymentRequest.RequestedBy
-	helper["resource_name"] = deploymentRequest.ResourceName
+	helper["resource_ids"] = deploymentRequest.ResourceIds
 	helper["status"] = deploymentRequest.Status
 	helper["total_tasks"] = deploymentRequest.TotalTasks
 	helper["updated_at"] = deploymentRequest.UpdatedAt.String()

--- a/vra/resource.go
+++ b/vra/resource.go
@@ -60,7 +60,7 @@ func resourcesSchema() *schema.Schema {
 	}
 }
 
-func flattenResources(resources []*models.Resource) []map[string]interface{} {
+func flattenResources(resources []*models.DeploymentResource) []map[string]interface{} {
 	if len(resources) == 0 {
 		return make([]map[string]interface{}, 0)
 	}

--- a/vra/resource_blueprint_test.go
+++ b/vra/resource_blueprint_test.go
@@ -70,7 +70,7 @@ func testAccCheckVRABlueprintDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := apiClient.Deployments.GetDeploymentByIDUsingGET(deployments.NewGetDeploymentByIDUsingGETParams().WithDepID(strfmt.UUID(rs.Primary.ID)))
+		_, err := apiClient.Deployments.GetDeploymentByIDUsingGET(deployments.NewGetDeploymentByIDUsingGETParams().WithDeploymentID(strfmt.UUID(rs.Primary.ID)))
 		if err == nil {
 			return fmt.Errorf("resource 'vra_blueprint' still exists with id %s", rs.Primary.ID)
 		}

--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -340,7 +340,7 @@ func resourceDeploymentRead(d *schema.ResourceData, m interface{}) error {
 
 	resp, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
 		deployments.NewGetDeploymentByIDUsingGETParams().
-			WithDepID(strfmt.UUID(id)).
+			WithDeploymentID(strfmt.UUID(id)).
 			WithExpandResources(withBool(true)).
 			WithExpandLastRequest(withBool(true)).
 			WithExpandProject(withBool(expandProject)).
@@ -469,7 +469,7 @@ func resourceDeploymentDelete(d *schema.ResourceData, m interface{}) error {
 	apiClient := m.(*Client).apiClient
 
 	id := d.Id()
-	_, err := apiClient.Deployments.DeleteDeploymentUsingDELETE(deployments.NewDeleteDeploymentUsingDELETEParams().WithDepID(strfmt.UUID(id)))
+	_, err := apiClient.Deployments.DeleteDeploymentUsingDELETE(deployments.NewDeleteDeploymentUsingDELETEParams().WithDeploymentID(strfmt.UUID(id)))
 	if err != nil {
 		return err
 	}
@@ -646,7 +646,7 @@ func deploymentStatusRefreshFunc(apiClient client.MulticloudIaaS, id string) res
 	return func() (interface{}, string, error) {
 		ret, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
 			deployments.NewGetDeploymentByIDUsingGETParams().
-				WithDepID(strfmt.UUID(id)).
+				WithDeploymentID(strfmt.UUID(id)).
 				WithExpandLastRequest(withBool(true)).
 				WithAPIVersion(withString(DeploymentsAPIVersion)))
 		if err != nil {
@@ -787,7 +787,7 @@ func updateDeploymentMetadata(d *schema.ResourceData, apiClient *client.Multiclo
 
 	log.Printf("[DEBUG] update deployment: %#v", updateDeploymentSpecification)
 	_, err := apiClient.Deployments.PatchDeploymentUsingPATCH(
-		deployments.NewPatchDeploymentUsingPATCHParams().WithDepID(deploymentUUID).WithUpdate(&updateDeploymentSpecification))
+		deployments.NewPatchDeploymentUsingPATCHParams().WithDeploymentID(deploymentUUID).WithUpdate(&updateDeploymentSpecification))
 	if err != nil {
 		return err
 	}
@@ -800,7 +800,7 @@ func runDeploymentUpdateAction(d *schema.ResourceData, apiClient *client.Multicl
 	log.Printf("Noticed changes to inputs. Starting to update deployment with inputs")
 	// Get the deployment actions
 	deploymentActions, err := apiClient.DeploymentActions.GetDeploymentActionsUsingGET(deployment_actions.
-		NewGetDeploymentActionsUsingGETParams().WithDepID(deploymentUUID))
+		NewGetDeploymentActionsUsingGETParams().WithDeploymentID(deploymentUUID))
 	if err != nil {
 		return err
 	}
@@ -944,7 +944,7 @@ func getInputTypesMapFromBlueprintInputsSchema(schema map[string]models.Property
 func getDeploymentDay2ActionID(apiClient *client.MulticloudIaaS, deploymentUUID strfmt.UUID, actionName string) (bool, string, error) {
 	// Get the deployment actions
 	deploymentActions, err := apiClient.DeploymentActions.GetDeploymentActionsUsingGET(deployment_actions.
-		NewGetDeploymentActionsUsingGETParams().WithDepID(deploymentUUID))
+		NewGetDeploymentActionsUsingGETParams().WithDeploymentID(deploymentUUID))
 	if err != nil {
 		return false, "", err
 	}
@@ -976,7 +976,7 @@ func getDeploymentActionSchema(apiClient *client.MulticloudIaaS, deploymentUUID 
 	var actionSchema interface{}
 
 	deploymentAction, err := apiClient.DeploymentActions.GetDeploymentActionUsingGET(deployment_actions.
-		NewGetDeploymentActionUsingGETParams().WithDepID(deploymentUUID).WithActionID(actionID))
+		NewGetDeploymentActionUsingGETParams().WithDeploymentID(deploymentUUID).WithActionID(actionID))
 	if err != nil {
 		return nil, err
 	}
@@ -1051,7 +1051,7 @@ func runAction(d *schema.ResourceData, apiClient *client.MulticloudIaaS, deploym
 	resp, err := apiClient.DeploymentActions.SubmitDeploymentActionRequestUsingPOST(
 		deployment_actions.NewSubmitDeploymentActionRequestUsingPOSTParams().
 			WithAPIVersion(withString(DeploymentsAPIVersion)).
-			WithDepID(deploymentUUID).
+			WithDeploymentID(deploymentUUID).
 			WithActionRequest(&resourceActionRequest))
 	if err != nil {
 		return err
@@ -1078,7 +1078,7 @@ func deploymentActionStatusRefreshFunc(apiClient client.MulticloudIaaS, deployme
 	return func() (interface{}, string, error) {
 		ret, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
 			deployments.NewGetDeploymentByIDUsingGETParams().
-				WithDepID(deploymentUUID).
+				WithDeploymentID(deploymentUUID).
 				WithExpandLastRequest(withBool(true)).
 				WithAPIVersion(withString(DeploymentsAPIVersion)).
 				WithTimeout(IncreasedTimeOut))
@@ -1104,7 +1104,7 @@ func deploymentActionStatusRefreshFunc(apiClient client.MulticloudIaaS, deployme
 func deploymentDeleteStatusRefreshFunc(apiClient client.MulticloudIaaS, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		ret, err := apiClient.Deployments.GetDeploymentByIDUsingGET(
-			deployments.NewGetDeploymentByIDUsingGETParams().WithDepID(strfmt.UUID(id)))
+			deployments.NewGetDeploymentByIDUsingGETParams().WithDeploymentID(strfmt.UUID(id)))
 		if err != nil {
 			switch err.(type) {
 			case *deployments.GetDeploymentByIDUsingGETNotFound:

--- a/vra/resource_deployment_test.go
+++ b/vra/resource_deployment_test.go
@@ -111,7 +111,7 @@ func testAccCheckVRADeploymentDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := apiClient.Deployments.GetDeploymentByIDUsingGET(deployments.NewGetDeploymentByIDUsingGETParams().WithDepID(strfmt.UUID(rs.Primary.ID)))
+		_, err := apiClient.Deployments.GetDeploymentByIDUsingGET(deployments.NewGetDeploymentByIDUsingGETParams().WithDeploymentID(strfmt.UUID(rs.Primary.ID)))
 		if err == nil {
 			return fmt.Errorf("resource 'vra_deployment' still exists with id %s", rs.Primary.ID)
 		}

--- a/vra/resource_project.go
+++ b/vra/resource_project.go
@@ -248,7 +248,7 @@ func resourceProjectDelete(d *schema.ResourceData, m interface{}) error {
 
 	// Workaround an issue where the cloud regions need to be removed before the project can be deleted.
 	_, err := apiClient.Project.UpdateProject(project.NewUpdateProjectParams().WithID(id).WithBody(&models.ProjectSpecification{
-		ZoneAssignmentConfigurations: []*models.ZoneAssignmentConfig{},
+		ZoneAssignmentConfigurations: []*models.ZoneAssignmentSpecification{},
 	}))
 	if err != nil {
 		return err
@@ -279,13 +279,13 @@ func expandUserListAndNewUserList(userList []interface{}, configUsers []interfac
 	return users
 }
 
-func expandZoneAssignment(configZoneAssignments []interface{}) []*models.ZoneAssignmentConfig {
-	zoneAssignments := make([]*models.ZoneAssignmentConfig, 0, len(configZoneAssignments))
+func expandZoneAssignment(configZoneAssignments []interface{}) []*models.ZoneAssignmentSpecification {
+	zoneAssignments := make([]*models.ZoneAssignmentSpecification, 0, len(configZoneAssignments))
 
 	for _, configZone := range configZoneAssignments {
 		configZoneAssignment := configZone.(map[string]interface{})
 
-		za := models.ZoneAssignmentConfig{
+		za := models.ZoneAssignmentSpecification{
 			CPULimit:           int64(configZoneAssignment["cpu_limit"].(int)),
 			MaxNumberInstances: int64(configZoneAssignment["max_instances"].(int)),
 			MemoryLimitMB:      int64(configZoneAssignment["memory_limit_mb"].(int)),
@@ -300,7 +300,7 @@ func expandZoneAssignment(configZoneAssignments []interface{}) []*models.ZoneAss
 	return zoneAssignments
 }
 
-func flattenZoneAssignment(list []*models.ZoneAssignmentConfig) []map[string]interface{} {
+func flattenZoneAssignment(list []*models.ZoneAssignment) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, zoneAssignment := range list {
 		l := map[string]interface{}{


### PR DESCRIPTION
Update the vra-sdk-go to [v0.2.21](https://github.com/vmware/vra-sdk-go/releases/tag/v0.2.21).

Signed-off-by: Ferran Rodenas <rodenasf@vmware.com>