### PR TITLE
Fix delete and update deployment when there is an error

### DIFF
--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -1089,8 +1089,10 @@ func deploymentActionStatusRefreshFunc(apiClient client.MulticloudIaaS, deployme
 		switch status {
 		case models.RequestStatusPENDING, models.RequestStatusINITIALIZATION, models.RequestStatusCHECKINGAPPROVAL, models.RequestStatusAPPROVALPENDING, models.RequestStatusINPROGRESS, models.RequestStatusCOMPLETION:
 			return [...]string{deploymentUUID.String()}, status, nil
-		case models.RequestStatusAPPROVALREJECTED, models.RequestStatusABORTED, models.RequestStatusFAILED:
+		case models.RequestStatusAPPROVALREJECTED, models.RequestStatusABORTED:
 			return []string{""}, status, fmt.Errorf(ret.Error())
+		case models.RequestStatusFAILED:
+			return [...]string{deploymentUUID.String()}, status, fmt.Errorf(ret.Payload.LastRequest.Details)
 		case models.RequestStatusSUCCESSFUL:
 			deploymentID := ret.Payload.ID
 			return deploymentID.String(), status, nil


### PR DESCRIPTION
* Fix delete deployment when there is an error (fixes #375)
* Show last request details when there is an error updating a deployment (fixes #372)