### PR TITLE
Fix vra_region data source regression

### DIFF
--- a/vra/data_source_region.go
+++ b/vra/data_source_region.go
@@ -62,7 +62,7 @@ func dataSourceRegion() *schema.Resource {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The specific region associated with the cloud account.",
+				Description: "The specific region associated with the cloud account. On vSphere, this is the external ID.",
 			},
 			"updated_at": {
 				Type:        schema.TypeString,
@@ -171,7 +171,8 @@ func dataSourceRegionRead(d *schema.ResourceData, meta interface{}) error {
 		var id string
 		cloudAccount := getResp.Payload
 		for _, enabledRegion := range cloudAccount.EnabledRegions {
-			if enabledRegion.Name == region {
+			// Look for the external region ID instead of the region name to be backwards compatible.
+			if *enabledRegion.ExternalRegionID == region {
 				id = *enabledRegion.ID
 				break
 			}

--- a/website/docs/d/vra_region.html.markdown
+++ b/website/docs/d/vra_region.html.markdown
@@ -43,7 +43,7 @@ The region data source supports the following arguments:
 
 * `id` - (Optional) The id of the region instance,
 
-* `region` - (Optional) The specific region associated with the cloud account.
+* `region` - (Optional) The specific region associated with the cloud account. On vSphere, this is the external ID.
 
 * `name` - (Optional) Name of region on the provider side. In vSphere, the name of the region is different from its id.
 


### PR DESCRIPTION
Fix a bug introduced at #386.

Commit https://github.com/vmware/terraform-provider-vra/pull/386/commits/d1dba66f6a6f95526b4b64554e408755dc943909 introduced a regression when looking for the `region` parameter. Before the commit, `region` indicated the external region id. The change looked for the region name instead. This commit restores the previous way of looking for the `region` parameter.

Signed-off-by: Ferran Rodenas <rodenasf@vmware.com>