### PR TITLE
Add GitHub Discussions to contact_links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/vmware/terraform-provider-vra/discussions
+    about: Having trouble working with the provider? Join the discussions to ask and answer questions in the community.


### PR DESCRIPTION
Added GitHub Discussions to contact_links to encourage discussion and collaboration.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>