### PR TITLE
Add `fabric_compute` datasource and resource

### DIFF
--- a/examples/fabric_compute/README.md
+++ b/examples/fabric_compute/README.md
@@ -1,0 +1,54 @@
+# fabric compute example
+
+**__NOTE: THIS RESOURCE TYPE MUST BE IMPORTED. ATTEMPTING TO CREATE IT WILL ERROR__ **
+
+These resources (fabric computes) are discovered in vRA(C) as part of creating a Cloud Account and can not therefore be "created" or "destroyed" in a traditional sense.
+
+This is an example on how to import a fabric compute resource into terraform and then manage settings on it.
+
+## Getting Started
+
+There are variables which need to be added to a `terraform.tfvars` file:
+
+* `url` - The base url for API operations
+* `refresh_token` - The refresh token for API operations
+* `insecure` - Specify whether to validate TLS certificates
+
+To facilitate adding these variables, a sample tfvars file can be copied first:
+
+```shell
+cp terraform.tfvars.sample terraform.tfvars
+```
+
+This examples assumes a cloud account is already set up.
+
+To import the resource you must find the ID of the fabric compute. There are a couple of way this ID can be aquired:
+
+1. Via API calls
+2. Viewing the object in a browser and pulling the ID from the url (ex value: `e2a959f4-7ec5-4941-b532-32b798309feb`)
+
+Once the information is added to `terraform.tfvars` the resource can be imported and the manage via:
+
+```shell
+terraform import vra_fabric_compute.this <computeID>
+```
+
+If the import is successful output from the command should resemble
+
+```shell
+vra_fabric_compute.this: Importing from ID "<computeID>"...
+vra_fabric_compute.this: Import prepared!
+  Prepared vra_fabric_compute for import
+vra_fabric_compute.this: Refreshing state... [id=<computeID>]
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform
+```
+
+To apply your settings you can now perform an apply comand:
+
+```shell
+terraform apply
+```

--- a/examples/fabric_compute/main.tf
+++ b/examples/fabric_compute/main.tf
@@ -1,0 +1,13 @@
+provider "vra" {
+  url           = var.url
+  refresh_token = var.refresh_token
+  insecure      = var.insecure
+}
+
+resource "vra_fabric_compute" "this" {
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+

--- a/examples/fabric_compute/terraform.tfvars.sample
+++ b/examples/fabric_compute/terraform.tfvars.sample
@@ -1,0 +1,3 @@
+url = ""
+refresh_token = ""
+insecure = ""

--- a/examples/fabric_compute/variables.tf
+++ b/examples/fabric_compute/variables.tf
@@ -1,0 +1,11 @@
+variable "url" {
+  description = "The base url for API operations"
+}
+
+variable "refresh_token" {
+  description = "The refresh token for API operations"
+}
+
+variable "insecure" {
+  description = "Specify whether to validate TLS certificates"
+}

--- a/vra/data_source_fabric_compute.go
+++ b/vra/data_source_fabric_compute.go
@@ -1,0 +1,165 @@
+package vra
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/client/fabric_compute"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+)
+
+func dataSourceFabricCompute() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFabricComputeRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"filter"},
+				Description:   "The id of the fabric compute resource instance.",
+				Optional:      true,
+			},
+			"filter": {
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"id"},
+				Description:   "Search criteria to narrow down the fabric compute resource instance.",
+				Optional:      true,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the entity was created. The date is in ISO 8601 and UTC.",
+			},
+			"custom_properties": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "A list of key value pair of custom properties for the fabric compute resource.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A human-friendly description.",
+			},
+			"external_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the external entity on the provider side.",
+			},
+			"external_region_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The external region id of the fabric compute.",
+			},
+			"external_zone_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The external zone id of the fabric compute.",
+			},
+			"lifecycle_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Lifecycle status of the compute instance.",
+			},
+			"links": linksSchema(),
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A human-friendly name used as an identifier for the fabric compute resource instance.",
+			},
+			"org_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the organization this entity belongs to.",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Email of the user that owns the entity.",
+			},
+			"power_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Power state of fabric compute instance.",
+			},
+			"tags": tagsSchema(),
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of the fabric compute instance.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the entity was last updated. The date is ISO 8601 and UTC.",
+			},
+		},
+	}
+}
+
+func dataSourceFabricComputeRead(d *schema.ResourceData, meta interface{}) error {
+	apiClient := meta.(*Client).apiClient
+
+	id := d.Get("id").(string)
+	filter := d.Get("filter").(string)
+
+	if id == "" && filter == "" {
+		return errors.New("one of id or filter is required")
+	}
+
+	var fabricCompute *models.FabricCompute
+	if id != "" {
+		getResp, err := apiClient.FabricCompute.GetFabricCompute(fabric_compute.NewGetFabricComputeParams().WithID(id))
+		if err != nil {
+			switch err.(type) {
+			case *fabric_compute.GetFabricComputeNotFound:
+				return fmt.Errorf("fabric compute '%s' not found", id)
+			default:
+				// nop
+			}
+			return err
+		}
+
+		fabricCompute = getResp.GetPayload()
+	} else {
+		getResp, err := apiClient.FabricCompute.GetFabricComputes(fabric_compute.NewGetFabricComputesParams().WithDollarFilter(&filter))
+		if err != nil {
+			return err
+		}
+
+		fabricComputes := getResp.GetPayload()
+		if len(fabricComputes.Content) > 1 {
+			return errors.New("must filter to one fabric compute")
+		}
+		if len(fabricComputes.Content) == 0 {
+			return fmt.Errorf("filter doesn't match to any fabric compute")
+		}
+
+		fabricCompute = fabricComputes.Content[0]
+	}
+
+	d.SetId(*fabricCompute.ID)
+	d.Set("created_at", fabricCompute.CreatedAt)
+	d.Set("custom_properties", fabricCompute.CustomProperties)
+	d.Set("description", fabricCompute.Description)
+	d.Set("external_id", fabricCompute.ExternalID)
+	d.Set("external_region_id", fabricCompute.ExternalRegionID)
+	d.Set("external_zone_id", fabricCompute.ExternalZoneID)
+	d.Set("lifecycle_state", fabricCompute.LifecycleState)
+	d.Set("name", fabricCompute.Name)
+	d.Set("org_id", fabricCompute.OrgID)
+	d.Set("owner", fabricCompute.Owner)
+	d.Set("power_state", fabricCompute.PowerState)
+	d.Set("type", fabricCompute.Type)
+	d.Set("updated_at", fabricCompute.UpdatedAt)
+
+	if err := d.Set("links", flattenLinks(fabricCompute.Links)); err != nil {
+		return fmt.Errorf("error setting zone links - error: %#v", err)
+	}
+
+	if err := d.Set("tags", flattenTags(fabricCompute.Tags)); err != nil {
+		return fmt.Errorf("error setting zone tags - error: %v", err)
+	}
+
+	return nil
+}

--- a/vra/data_source_fabric_compute_test.go
+++ b/vra/data_source_fabric_compute_test.go
@@ -1,0 +1,57 @@
+package vra
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFabricCompute_Basic(t *testing.T) {
+	regionName := os.Getenv("VRA_FABRIC_COMPUTE_NAME")
+	dataSourceName := "data.vra_fabric_compute.my-fabric-compute"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckFabricCompute(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceVRAFabricComputeNoConfig(),
+				ExpectError: regexp.MustCompile("one of id or filter is required"),
+			},
+			{
+				Config:      testAccDataSourceVRAFabricComputeNoneConfig(),
+				ExpectError: regexp.MustCompile("filter doesn't match to any fabric compute"),
+			},
+			{
+				Config: testAccDataSourceVRAFabricComputeOneConfig(regionName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "external_id", regionName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", regionName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceVRAFabricComputeNoConfig() string {
+	return `
+		data "vra_fabric_compute" "my-fabric-compute" {
+		}`
+}
+
+func testAccDataSourceVRAFabricComputeNoneConfig() string {
+	return `
+		data "vra_fabric_compute" "my-fabric-compute" {
+			filter = "name eq 'foobar'"
+		}`
+}
+
+func testAccDataSourceVRAFabricComputeOneConfig(regionName string) string {
+	return fmt.Sprintf(`
+		data "vra_fabric_compute" "my-fabric-compute" {
+			filter = "name eq '%s'"
+		}`, regionName)
+}

--- a/vra/provider.go
+++ b/vra/provider.go
@@ -104,6 +104,7 @@ func Provider() *schema.Provider {
 			"vra_cloud_account_vsphere":      resourceCloudAccountVsphere(),
 			"vra_content_source":             resourceContentSource(),
 			"vra_deployment":                 resourceDeployment(),
+			"vra_fabric_compute":             resourceFabricCompute(),
 			"vra_fabric_network_vsphere":     resourceFabricNetworkVsphere(),
 			"vra_flavor_profile":             resourceFlavorProfile(),
 			"vra_image_profile":              resourceImageProfile(),

--- a/vra/provider.go
+++ b/vra/provider.go
@@ -61,6 +61,7 @@ func Provider() *schema.Provider {
 			"vra_cloud_account_vsphere":         dataSourceCloudAccountVsphere(),
 			"vra_data_collector":                dataSourceDataCollector(),
 			"vra_deployment":                    dataSourceDeployment(),
+			"vra_fabric_compute":                dataSourceFabricCompute(),
 			"vra_fabric_datastore_vsphere":      dataSourceFabricDatastoreVsphere(),
 			"vra_fabric_network":                dataSourceFabricNetwork(),
 			"vra_fabric_storage_account_azure":  dataSourceFabricStorageAccountAzure(),

--- a/vra/provider_test.go
+++ b/vra/provider_test.go
@@ -528,3 +528,20 @@ func testAccPreCheckFabricStorageAccountAzure(t *testing.T) {
 		}
 	}
 }
+
+func testAccPreCheckFabricCompute(t *testing.T) {
+	if os.Getenv("VRA_REFRESH_TOKEN") == "" && os.Getenv("VRA_ACCESS_TOKEN") == "" {
+		t.Fatal("VRA_REFRESH_TOKEN or VRA_ACCESS_TOKEN must be set for acceptance tests")
+	}
+
+	envVars := [...]string{
+		"VRA_URL",
+		"VRA_FABRIC_COMPUTE_NAME",
+	}
+
+	for _, name := range envVars {
+		if v := os.Getenv(name); v == "" {
+			t.Fatalf("%s must be set for acceptance tests\n", name)
+		}
+	}
+}

--- a/vra/resource_fabric_compute.go
+++ b/vra/resource_fabric_compute.go
@@ -1,0 +1,161 @@
+package vra
+
+import (
+	"context"
+	"errors"
+
+	"github.com/vmware/vra-sdk-go/pkg/client/fabric_compute"
+	"github.com/vmware/vra-sdk-go/pkg/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceFabricCompute() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFabricComputeCreate,
+		ReadContext:   resourceFabricComputeRead,
+		UpdateContext: resourceFabricComputeUpdate,
+		DeleteContext: resourceFabricComputeDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the entity was created. The date is in ISO 8601 and UTC.",
+			},
+			"custom_properties": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "A list of key value pair of custom properties for the fabric compute resource.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A human-friendly description.",
+			},
+			"external_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the external entity on the provider side.",
+			},
+			"external_region_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The external region id of the fabric compute.",
+			},
+			"external_zone_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The external zone id of the fabric compute.",
+			},
+			"lifecycle_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Lifecycle status of the compute instance.",
+			},
+			"links": linksSchema(),
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "A human-friendly name used as an identifier for the fabric compute resource instance.",
+			},
+			"org_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the organization this entity belongs to.",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Email of the user that owns the entity.",
+			},
+			"power_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Power state of fabric compute instance.",
+			},
+			"tags": tagsSchema(),
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of the fabric compute instance.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the entity was last updated. The date is ISO 8601 and UTC.",
+			},
+		},
+	}
+}
+
+func resourceFabricComputeCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return diag.FromErr(errors.New("vra_fabric_compute resources are only importable"))
+}
+
+func resourceFabricComputeRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	apiClient := m.(*Client).apiClient
+
+	id := d.Id()
+
+	getResp, err := apiClient.FabricCompute.GetFabricCompute(fabric_compute.NewGetFabricComputeParams().WithID(id))
+	if err != nil {
+		switch err.(type) {
+		case *fabric_compute.GetFabricComputeNotFound:
+			return diag.Errorf("fabric compute '%s' not found", id)
+		default:
+			// nop
+		}
+		return diag.FromErr(err)
+	}
+
+	fabricCompute := getResp.GetPayload()
+	d.SetId(*fabricCompute.ID)
+	d.Set("created_at", fabricCompute.CreatedAt)
+	d.Set("custom_properties", fabricCompute.CustomProperties)
+	d.Set("description", fabricCompute.Description)
+	d.Set("external_id", fabricCompute.ExternalID)
+	d.Set("external_region_id", fabricCompute.ExternalRegionID)
+	d.Set("external_zone_id", fabricCompute.ExternalZoneID)
+	d.Set("lifecycle_state", fabricCompute.LifecycleState)
+	d.Set("name", fabricCompute.Name)
+	d.Set("org_id", fabricCompute.OrgID)
+	d.Set("owner", fabricCompute.Owner)
+	d.Set("power_state", fabricCompute.PowerState)
+	d.Set("type", fabricCompute.Type)
+	d.Set("updated_at", fabricCompute.UpdatedAt)
+
+	if err := d.Set("links", flattenLinks(fabricCompute.Links)); err != nil {
+		return diag.Errorf("error setting zone links - error: %#v", err)
+	}
+
+	if err := d.Set("tags", flattenTags(fabricCompute.Tags)); err != nil {
+		return diag.Errorf("error setting zone tags - error: %v", err)
+	}
+
+	return nil
+}
+
+func resourceFabricComputeUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	apiClient := m.(*Client).apiClient
+
+	id := d.Id()
+
+	fabricComputeSpecification := &models.FabricComputeSpecification{
+		Tags: expandTags(d.Get("tags").(*schema.Set).List()),
+	}
+
+	if _, err := apiClient.FabricCompute.UpdateFabricCompute(fabric_compute.NewUpdateFabricComputeParams().WithID(id).WithBody(fabricComputeSpecification)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceFabricComputeRead(ctx, d, m)
+}
+
+func resourceFabricComputeDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return nil
+}

--- a/vra/resource_fabric_compute_test.go
+++ b/vra/resource_fabric_compute_test.go
@@ -1,0 +1,70 @@
+package vra
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/vra-sdk-go/pkg/client/fabric_compute"
+)
+
+func TestAccVRAFabricCompute_importBasic(t *testing.T) {
+	resourceName := "vra_fabric_compute.this"
+	fabricComputeID := os.Getenv("VRA_FABRIC_COMPUTE_ID")
+
+	checkFn := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 state %#v", s)
+		}
+
+		fabricComputeState := s[0]
+		if fabricComputeID != fabricComputeState.ID {
+			return fmt.Errorf("expected fabric compute ID of %s,%s received instead", fabricComputeID, fabricComputeState.ID)
+		}
+		return nil
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckFabricCompute(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVRAFabricComputeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckVRAFabricComputeConfig(),
+				ExpectError: regexp.MustCompile("vra_fabric_compute resources are only importable"),
+			},
+			{
+				Config:           testAccCheckVRAFabricComputeConfig(),
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateId:    fabricComputeID,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}
+
+func testAccCheckVRAFabricComputeDestroy(s *terraform.State) error {
+	apiClient := testAccProviderVRA.Meta().(*Client).apiClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "vra_fabric_compute" {
+			if _, err := apiClient.FabricCompute.GetFabricCompute(fabric_compute.NewGetFabricComputeParams().WithID(rs.Primary.ID)); err == nil {
+				return fmt.Errorf("Resource 'vra_fabric_compute' with id `%s` does not exist", rs.Primary.ID)
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func testAccCheckVRAFabricComputeConfig() string {
+	regionName := os.Getenv("VRA_FABRIC_COMPUTE_NAME")
+	return fmt.Sprintf(`
+		resource "vra_fabric_compute" "this" {
+			name = "%s"
+		}`, regionName)
+}

--- a/website/docs/d/fabric_compute.html.markdown
+++ b/website/docs/d/fabric_compute.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "vra"
+page_title: "VMware vRealize Automation: fabric_compute"
+description: |-
+  Provides a data lookup for vRA fabric computes.
+---
+
+# Data Source: fabric_compute
+
+## Example Usages
+
+This is an example of how to lookup fabric computes.
+
+**Fabric compute data source by Id:**
+
+```hcl
+# Lookup fabric compute using its id
+data "vra_fabric_compute" "this" {
+  id = var.fabric_compute_id
+}
+```
+
+**Fabric compute data source by filter query:**
+
+```hcl
+# Lookup fabric compute using its name
+data "fabric_compute" "this" {
+  filter = "name eq '${var.fabric_compute_name}'"
+}
+```
+
+A fabric compute data source supports the following arguments:
+
+## Argument Reference
+
+* `id` - (Optional) The id of the fabric compute resource instance. Only one of 'id' or 'filter' must be specified.
+
+* `filter` - (Optional) Search criteria to narrow down the fabric compute resource instance. Only one of 'id' or 'filter' must be specified.
+
+## Attribute Reference
+
+* `created_at` - Date when the entity was created. The date is in ISO 8601 and UTC.
+
+* `custom_properties` - A list of key value pair of custom properties for the fabric compute resource.
+
+* `description` - A human-friendly description.
+
+* `external_id` - The id of the external entity on the provider side.
+
+* `external_region_id` - The external region id of the fabric compute.
+
+* `external_zone_id` - The external zone id of the fabric compute.
+
+* `lifecycle_state` - Lifecycle status of the compute instance.
+
+* `links` - HATEOAS of the entity.
+
+* `name` - A human-friendly name used as an identifier for the fabric compute resource instance.
+
+* `org_id` - The id of the organization this entity belongs to.
+
+* `owner` - Email of the user that owns the entity.
+
+* `power_state` - Power state of fabric compute instance.
+
+* `tags` -  A set of tag keys and optional values that were set on this resource:
+  * `key` - Tag’s key.
+  * `value` - Tag’s value.
+
+* `type` - Type of the fabric compute instance.
+
+* `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/r/fabric_compute.html.markdown
+++ b/website/docs/r/fabric_compute.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "vra"
+page_title: "VMware vRealize Automation: fabric_compute"
+description: |-
+  Updates a fabric_compute resource.
+---
+
+# Resource: fabric_compute
+
+Updates a VMware vRealize Automation fabric_compute resource.
+
+## Example Usages
+
+You cannot create a fabric compute resource, however you can import it using the command specified in the import section below.
+
+Once a resource is imported, you can update it as shown below:
+
+```hcl
+resource "fabric_compute" "this" {
+  tags {
+    key   = "foo"
+    value = "bar"
+  }
+}
+```
+## Argument Reference
+
+* `tags` -  A set of tag keys and optional values that were set on this resource:
+  * `key` - Tag’s key.
+  * `value` - Tag’s value.
+
+## Attribute Reference
+
+* `created_at` - Date when the entity was created. The date is in ISO 8601 and UTC.
+
+* `custom_properties` - A list of key value pair of custom properties for the fabric compute resource.
+
+* `description` - A human-friendly description.
+
+* `external_id` - The id of the external entity on the provider side.
+
+* `external_region_id` - The external region id of the fabric compute.
+
+* `external_zone_id` - The external zone id of the fabric compute.
+
+* `lifecycle_state` - Lifecycle status of the compute instance.
+
+* `links` - HATEOAS of the entity.
+
+* `name` - A human-friendly name used as an identifier for the fabric compute resource instance.
+
+* `org_id` - The id of the organization this entity belongs to.
+
+* `owner` - Email of the user that owns the entity.
+
+* `power_state` - Power state of fabric compute instance.
+
+* `type` - Type of the fabric compute instance.
+
+* `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.
+
+## Import
+
+To import the fabric compute resource, use the ID as in the following example:
+
+`$ terraform import vra_fabric_compute.this 88fdea8b-92ed-4aa9-b6ee-4670412961b0


### PR DESCRIPTION
* Adds a new `fabric_compute` datasource, which can be used when assigning `compute resources` to a `zone` (see https://github.com/vmware/terraform-provider-vra/pull/391)
* Adds a new `fabric_compute` resource which can be imported and updated (Fixes https://github.com/vmware/terraform-provider-vra/issues/337)