### PR TITLE
Fix the compute_ids list of a region

### DIFF
--- a/vra/resource_zone.go
+++ b/vra/resource_zone.go
@@ -194,7 +194,7 @@ func resourceZoneRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	var computeIds []string
 	for _, compute := range getComputesResp.Payload.Content {
-		computeIds = append(computeIds, compute.Name)
+		computeIds = append(computeIds, *compute.ID)
 	}
 	d.Set("compute_ids", computeIds)
 


### PR DESCRIPTION
When reading a zone are the [vra_zone](https://github.com/vmware/terraform-provider-vra/blob/main/vra/resource_zone.go) resource, the `compute_ids` field should return the list of ids and not the name of the compute resources.