### PR TITLE
Use Set as attribute type for unordered list of items

### DIFF
--- a/vra/data_source_block_device.go
+++ b/vra/data_source_block_device.go
@@ -37,7 +37,7 @@ func dataSourceBlockDevice() *schema.Resource {
 				Description: "Capacity of the block device in GB.",
 			},
 			"cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_blueprint.go
+++ b/vra/data_source_blueprint.go
@@ -32,7 +32,7 @@ func dataSourceBlueprint() *schema.Resource {
 				Computed: true,
 			},
 			"content_source_sync_messages": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_catalog_item.go
+++ b/vra/data_source_catalog_item.go
@@ -53,7 +53,7 @@ func dataSourceCatalogItem() *schema.Resource {
 				Computed: true,
 			},
 			"project_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_catalog_source_blueprint.go
+++ b/vra/data_source_catalog_source_blueprint.go
@@ -57,7 +57,7 @@ func dataSourceCatalogSourceBlueprint() *schema.Resource {
 				Computed: true,
 			},
 			"last_import_errors": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_cloud_account_aws.go
+++ b/vra/data_source_cloud_account_aws.go
@@ -50,7 +50,7 @@ func dataSourceCloudAccountAWS() *schema.Resource {
 				Computed: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_cloud_account_azure.go
+++ b/vra/data_source_cloud_account_azure.go
@@ -50,7 +50,7 @@ func dataSourceCloudAccountAzure() *schema.Resource {
 				Computed: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_cloud_account_gcp.go
+++ b/vra/data_source_cloud_account_gcp.go
@@ -57,7 +57,7 @@ func dataSourceCloudAccountGCP() *schema.Resource {
 				Computed: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_cloud_account_nsxt.go
+++ b/vra/data_source_cloud_account_nsxt.go
@@ -30,7 +30,7 @@ func dataSourceCloudAccountNSXT() *schema.Resource {
 			},
 			// Computed attributes
 			"associated_cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_cloud_account_nsxv.go
+++ b/vra/data_source_cloud_account_nsxv.go
@@ -28,7 +28,7 @@ func dataSourceCloudAccountNSXV() *schema.Resource {
 			},
 			// Computed attributes
 			"associated_cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_cloud_account_vmc.go
+++ b/vra/data_source_cloud_account_vmc.go
@@ -53,7 +53,7 @@ func dataSourceCloudAccountVMC() *schema.Resource {
 				Computed: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_cloud_account_vsphere.go
+++ b/vra/data_source_cloud_account_vsphere.go
@@ -19,7 +19,7 @@ func dataSourceCloudAccountVsphere() *schema.Resource {
 				Computed: true,
 			},
 			"associated_cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -42,7 +42,7 @@ func dataSourceCloudAccountVsphere() *schema.Resource {
 				Computed: true,
 			},
 			"enabled_region_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_fabric_datastore_vsphere.go
+++ b/vra/data_source_fabric_datastore_vsphere.go
@@ -27,7 +27,7 @@ func dataSourceFabricDatastoreVsphere() *schema.Resource {
 				Optional:      true,
 			},
 			"cloud_account_ids": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "Set of ids of the cloud accounts this entity belongs to.",
 				Elem: &schema.Schema{

--- a/vra/data_source_fabric_network.go
+++ b/vra/data_source_fabric_network.go
@@ -46,7 +46,7 @@ func dataSourceFabricNetwork() *schema.Resource {
 				Computed: true,
 			},
 			"cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_fabric_storage_account_azure.go
+++ b/vra/data_source_fabric_storage_account_azure.go
@@ -16,7 +16,7 @@ func dataSourceFabricStorageAccountAzure() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_fabric_storage_policy_vsphere.go
+++ b/vra/data_source_fabric_storage_policy_vsphere.go
@@ -14,7 +14,7 @@ func dataSourceFabricStoragePolicyVsphere() *schema.Resource {
 		Read: dataSourceFabricStoragePolicyVsphereRead,
 		Schema: map[string]*schema.Schema{
 			"cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_network_domain.go
+++ b/vra/data_source_network_domain.go
@@ -42,7 +42,7 @@ func dataSourceNetworkDomain() *schema.Resource {
 				Computed: true,
 			},
 			"cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_network_profile.go
+++ b/vra/data_source_network_profile.go
@@ -29,7 +29,7 @@ func dataSourceNetworkProfile() *schema.Resource {
 				Computed: true,
 			},
 			"fabric_network_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -82,7 +82,7 @@ func dataSourceNetworkProfile() *schema.Resource {
 				Computed: true,
 			},
 			"security_group_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_project.go
+++ b/vra/data_source_project.go
@@ -97,7 +97,7 @@ func dataSourceProject() *schema.Resource {
 			},
 			"viewer_roles": userSchema("List of viewer roles associated with the project."),
 			"zone_assignments": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "List of configurations for zone assignment to a project.",
 				Elem: &schema.Resource{

--- a/vra/data_source_region_enumeration.go
+++ b/vra/data_source_region_enumeration.go
@@ -35,7 +35,7 @@ func dataSourceRegionEnumeration() *schema.Resource {
 				Required: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_region_enumeration_aws.go
+++ b/vra/data_source_region_enumeration_aws.go
@@ -16,7 +16,7 @@ func dataSourceRegionEnumerationAWS() *schema.Resource {
 				Optional: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_region_enumeration_azure.go
+++ b/vra/data_source_region_enumeration_azure.go
@@ -21,7 +21,7 @@ func dataSourceRegionEnumerationAzure() *schema.Resource {
 				Sensitive: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_region_enumeration_gcp.go
+++ b/vra/data_source_region_enumeration_gcp.go
@@ -29,7 +29,7 @@ func dataSourceRegionEnumerationGCP() *schema.Resource {
 				Required: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_region_enumeration_vmc.go
+++ b/vra/data_source_region_enumeration_vmc.go
@@ -25,7 +25,7 @@ func dataSourceRegionEnumerationVMC() *schema.Resource {
 				Optional: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_region_enumeration_vsphere.go
+++ b/vra/data_source_region_enumeration_vsphere.go
@@ -34,7 +34,7 @@ func dataSourceRegionEnumerationVsphere() *schema.Resource {
 				Required: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_vra_machine.go
+++ b/vra/data_source_vra_machine.go
@@ -27,7 +27,7 @@ func dataSourceMachine() *schema.Resource {
 				Computed: true,
 			},
 			"cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/data_source_zone.go
+++ b/vra/data_source_zone.go
@@ -34,7 +34,7 @@ func dataSourceZone() *schema.Resource {
 				Description: "The ID of the cloud account this zone belongs to.",
 			},
 			"compute_ids": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "The ids of the compute resources that has been explicitly assigned to this zone.",
 				Elem: &schema.Schema{

--- a/vra/deployment_request.go
+++ b/vra/deployment_request.go
@@ -99,7 +99,7 @@ func deploymentRequestSchema() *schema.Schema {
 					Computed: true,
 				},
 				"resource_ids": {
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					Optional: true,
 					Computed: true,
 					Elem: &schema.Schema{

--- a/vra/links.go
+++ b/vra/links.go
@@ -22,7 +22,7 @@ func linksSchema() *schema.Schema {
 					Optional: true,
 				},
 				"hrefs": {
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,

--- a/vra/nics.go
+++ b/vra/nics.go
@@ -38,7 +38,7 @@ func nicsSchema(isRequired bool) *schema.Schema {
 					},
 				},
 				"security_group_ids": {
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,

--- a/vra/resource.go
+++ b/vra/resource.go
@@ -10,7 +10,7 @@ import (
 // resourcesSchema returns the schema to use for the resource property
 func resourcesSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -19,7 +19,7 @@ func resourcesSchema() *schema.Schema {
 					Optional: true,
 				},
 				"depends_on": {
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,

--- a/vra/resource_blueprint.go
+++ b/vra/resource_blueprint.go
@@ -41,7 +41,7 @@ func resourceBlueprint() *schema.Resource {
 				Computed: true,
 			},
 			"content_source_sync_messages": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/resource_catalog_source_blueprint.go
+++ b/vra/resource_catalog_source_blueprint.go
@@ -61,7 +61,7 @@ func resourceCatalogSourceBlueprint() *schema.Resource {
 				Computed: true,
 			},
 			"last_import_errors": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/resource_cloud_account_aws.go
+++ b/vra/resource_cloud_account_aws.go
@@ -42,7 +42,7 @@ func resourceCloudAccountAWS() *schema.Resource {
 				Optional: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -64,7 +64,7 @@ func resourceCloudAccountAWS() *schema.Resource {
 				Computed: true,
 			},
 			"region_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -90,10 +90,10 @@ func resourceCloudAccountAWSCreate(ctx context.Context, d *schema.ResourceData, 
 	tags := expandTags(d.Get("tags").(*schema.Set).List())
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified regions are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 
 	createResp, err := apiClient.CloudAccount.CreateAwsCloudAccount(cloud_account.NewCreateAwsCloudAccountParams().WithBody(&models.CloudAccountAwsSpecification{
@@ -180,10 +180,10 @@ func resourceCloudAccountAWSUpdate(ctx context.Context, d *schema.ResourceData, 
 	tags := expandTags(d.Get("tags").(*schema.Set).List())
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified regions are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 	_, err := apiClient.CloudAccount.UpdateAwsCloudAccount(cloud_account.NewUpdateAwsCloudAccountParams().WithID(id).WithBody(&models.UpdateCloudAccountAwsSpecification{
 		CreateDefaultZones: false,

--- a/vra/resource_cloud_account_azure.go
+++ b/vra/resource_cloud_account_azure.go
@@ -49,7 +49,7 @@ func resourceCloudAccountAzure() *schema.Resource {
 				Optional: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -71,7 +71,7 @@ func resourceCloudAccountAzure() *schema.Resource {
 				Computed: true,
 			},
 			"region_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -91,10 +91,10 @@ func resourceCloudAccountAzureCreate(ctx context.Context, d *schema.ResourceData
 	apiClient := m.(*Client).apiClient
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified regions are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 
 	applicationKey := d.Get("application_key").(string)
@@ -175,10 +175,10 @@ func resourceCloudAccountAzureUpdate(ctx context.Context, d *schema.ResourceData
 	id := d.Id()
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified regions are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 	tags := expandTags(d.Get("tags").(*schema.Set).List())
 

--- a/vra/resource_cloud_account_gcp.go
+++ b/vra/resource_cloud_account_gcp.go
@@ -50,7 +50,7 @@ func resourceCloudAccountGCP() *schema.Resource {
 				Optional: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -72,7 +72,7 @@ func resourceCloudAccountGCP() *schema.Resource {
 				Computed: true,
 			},
 			"region_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -92,10 +92,10 @@ func resourceCloudAccountGCPCreate(ctx context.Context, d *schema.ResourceData, 
 	apiClient := m.(*Client).apiClient
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
+		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 
 	createResp, err := apiClient.CloudAccount.CreateGcpCloudAccount(cloud_account.NewCreateGcpCloudAccountParams().WithBody(&models.CloudAccountGcpSpecification{
@@ -173,10 +173,10 @@ func resourceCloudAccountGCPUpdate(ctx context.Context, d *schema.ResourceData, 
 	id := d.Id()
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
+		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 	tags := expandTags(d.Get("tags").(*schema.Set).List())
 

--- a/vra/resource_cloud_account_nsxt.go
+++ b/vra/resource_cloud_account_nsxt.go
@@ -68,7 +68,7 @@ func resourceCloudAccountNSXT() *schema.Resource {
 			"tags": tagsSchema(),
 			// Computed attributes
 			"associated_cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/resource_cloud_account_nsxv.go
+++ b/vra/resource_cloud_account_nsxv.go
@@ -56,7 +56,7 @@ func resourceCloudAccountNSXV() *schema.Resource {
 			"tags": tagsSchema(),
 			// Computed attributes
 			"associated_cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/resource_cloud_account_vmc.go
+++ b/vra/resource_cloud_account_vmc.go
@@ -37,7 +37,7 @@ func resourceCloudAccountVMC() *schema.Resource {
 				Required: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -90,7 +90,7 @@ func resourceCloudAccountVMC() *schema.Resource {
 				Computed: true,
 			},
 			"region_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -111,10 +111,10 @@ func resourceCloudAccountVMCCreate(ctx context.Context, d *schema.ResourceData, 
 
 	tags := expandTags(d.Get("tags").(*schema.Set).List())
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
+		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 
 	cloudAccountProperties := make(map[string]string)
@@ -217,10 +217,10 @@ func resourceCloudAccountVMCUpdate(ctx context.Context, d *schema.ResourceData, 
 	id := d.Id()
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
+		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 
 	_, err := apiClient.CloudAccount.UpdateCloudAccount(cloud_account.NewUpdateCloudAccountParams().WithID(id).WithBody(&models.UpdateCloudAccountSpecification{

--- a/vra/resource_cloud_account_vsphere.go
+++ b/vra/resource_cloud_account_vsphere.go
@@ -37,7 +37,7 @@ func resourceCloudAccountVsphere() *schema.Resource {
 				Sensitive: true,
 			},
 			"regions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -54,7 +54,7 @@ func resourceCloudAccountVsphere() *schema.Resource {
 				Default:  false,
 			},
 			"associated_cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -88,7 +88,7 @@ func resourceCloudAccountVsphere() *schema.Resource {
 				Computed: true,
 			},
 			"region_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -109,17 +109,17 @@ func resourceCloudAccountVsphereCreate(ctx context.Context, d *schema.ResourceDa
 
 	tags := expandTags(d.Get("tags").(*schema.Set).List())
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified regions are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("associated_cloud_account_ids"); ok {
-		if !compareUnique(v.([]interface{})) {
+		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified associated cloud account ids are not unique"))
 		}
-		associatedCloudAccountIds = expandStringList(v.([]interface{}))
+		associatedCloudAccountIds = expandStringList(v.(*schema.Set).List())
 	}
 
 	createResp, err := apiClient.CloudAccount.CreateVSphereCloudAccount(
@@ -215,10 +215,10 @@ func resourceCloudAccountVsphereUpdate(ctx context.Context, d *schema.ResourceDa
 	id := d.Id()
 
 	if v, ok := d.GetOk("regions"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified regions are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified regions are not unique"))
 		}
-		regions = expandStringList(v.([]interface{}))
+		regions = expandStringList(v.(*schema.Set).List())
 	}
 	_, err := apiClient.CloudAccount.UpdateVSphereCloudAccount(cloud_account.NewUpdateVSphereCloudAccountParams().WithID(id).WithBody(&models.UpdateCloudAccountVsphereSpecification{
 		CreateDefaultZones: false,

--- a/vra/resource_fabric_network_vsphere.go
+++ b/vra/resource_fabric_network_vsphere.go
@@ -34,7 +34,7 @@ func resourceFabricNetworkVsphere() *schema.Resource {
 				Computed: true,
 			},
 			"cloud_account_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/vra/resource_network_profile.go
+++ b/vra/resource_network_profile.go
@@ -51,7 +51,7 @@ func resourceNetworkProfile() *schema.Resource {
 				Optional: true,
 			},
 			"fabric_network_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -78,7 +78,7 @@ func resourceNetworkProfile() *schema.Resource {
 				Optional: true,
 			},
 			"security_group_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -134,17 +134,17 @@ func resourceNetworkProfileCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if v, ok := d.GetOk("fabric_network_ids"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified fabric network ids are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified fabric network ids are not unique"))
 		}
-		networkProfileSpecification.FabricNetworkIds = expandStringList(v.([]interface{}))
+		networkProfileSpecification.FabricNetworkIds = expandStringList(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("security_group_ids"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified security group ids are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified security group ids are not unique"))
 		}
-		networkProfileSpecification.SecurityGroupIds = expandStringList(v.([]interface{}))
+		networkProfileSpecification.SecurityGroupIds = expandStringList(v.(*schema.Set).List())
 	}
 
 	log.Printf("[DEBUG] create network profile: %#v", networkProfileSpecification)
@@ -236,17 +236,17 @@ func resourceNetworkProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if v, ok := d.GetOk("fabric_network_ids"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified fabric network ids are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified fabric network ids are not unique"))
 		}
-		networkProfileSpecification.FabricNetworkIds = expandStringList(v.([]interface{}))
+		networkProfileSpecification.FabricNetworkIds = expandStringList(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("security_group_ids"); ok {
-		if !compareUnique(v.([]interface{})) {
-			return diag.FromErr(errors.New("Specified security group ids are not unique"))
+		if !compareUnique(v.(*schema.Set).List()) {
+			return diag.FromErr(errors.New("specified security group ids are not unique"))
 		}
-		networkProfileSpecification.SecurityGroupIds = expandStringList(v.([]interface{}))
+		networkProfileSpecification.SecurityGroupIds = expandStringList(v.(*schema.Set).List())
 	}
 
 	_, err := apiClient.NetworkProfile.UpdateNetworkProfile(network_profile.NewUpdateNetworkProfileParams().WithID(id).WithBody(&networkProfileSpecification))

--- a/vra/resource_zone.go
+++ b/vra/resource_zone.go
@@ -36,7 +36,7 @@ func resourceZone() *schema.Resource {
 
 			// Optional arguments
 			"compute_ids": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Computed:    true, // it needs to be computed because vRA will add compute ids besides the ones specified in the terraform plan
 				Description: "The ids of the compute resources that will be explicitly assigned to this zone.",
 				Optional:    true,
@@ -121,10 +121,10 @@ func resourceZoneCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 	var computeIds []string
 	if v, ok := d.GetOk("compute_ids"); ok {
-		if !compareUnique(v.([]interface{})) {
+		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified compute_ids are not unique"))
 		}
-		computeIds = expandStringList(v.([]interface{}))
+		computeIds = expandStringList(v.(*schema.Set).List())
 	}
 
 	createResp, err := apiClient.Location.CreateZone(location.NewCreateZoneParams().WithBody(&models.ZoneSpecification{
@@ -210,10 +210,10 @@ func resourceZoneUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 	var computeIds []string
 	if v, ok := d.GetOk("compute_ids"); ok {
-		if !compareUnique(v.([]interface{})) {
+		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified compute_ids are not unique"))
 		}
-		computeIds = expandStringList(v.([]interface{}))
+		computeIds = expandStringList(v.(*schema.Set).List())
 	}
 
 	if _, err := apiClient.Location.UpdateZone(location.NewUpdateZoneParams().WithID(id).WithBody(&models.ZoneSpecification{

--- a/vra/routes.go
+++ b/vra/routes.go
@@ -15,7 +15,7 @@ func routesSchema(isRequired bool) *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"health_check_configuration": {
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/vra/snapshots.go
+++ b/vra/snapshots.go
@@ -9,7 +9,7 @@ import (
 // snapshotsSchema returns the schema to use for the snapshots property
 func snapshotsSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
`TypeList` represents an ordered collection of items. `TypeSet` represents an unordered collection of items.

Switching attributes to Set when order does not matter. This will fix an issue when repeated applies without
any changes try to update the resource due to a list of items in a different order.

See related issue #358.

Signed-off-by: Ferran Rodenas <rodenasf@vmware.com>