### PR TITLE
Update `health_check_configuration`

### DIFF
--- a/vra/resource_load_balancer_test.go
+++ b/vra/resource_load_balancer_test.go
@@ -192,7 +192,7 @@ resource "vra_flavor_profile" "my-flavor-profile" {
 	}
 }
 
-resource "vra_machine" "my_machine" {
+resource "vra_machine" "my-machine" {
 	name        = "my-machine-%d"
 	description = "test machine updated"
 	project_id  = vra_project.my-project.id
@@ -211,13 +211,16 @@ resource "vra_machine" "my_machine" {
 func testAccCheckVRALoadBalancerNoTargetLinkConfig(rInt int) string {
 
 	return testAccCheckVRALoadBalancer(rInt) + fmt.Sprintf(`
-	resource "vra_load_balancer" "my_load_balancer" {
-		name = "my-lb-%d"
+	resource "vra_load_balancer" "my-load-balancer" {
+		name = "my-load-balancer"
 		project_id = vra_project.my-project.id
-		description = "load balancer description"
-
+		description = "My Load Balancer"
+		custom_properties = {
+			"edgeClusterRouterStateLink" = "/resources/routers/<uuid>"
+			"tier0LogicalRouterStateLink" = "/resources/routers/<uuid>"
+		}
 		targets {
-			machine_id = "invalid-machine-id"
+			machine_id = data.vra_machine.my-machine.id
 		}
 
 		nics {
@@ -229,7 +232,7 @@ func testAccCheckVRALoadBalancerNoTargetLinkConfig(rInt int) string {
 			port = "80"
 			member_protocol = "TCP"
 			member_port = "80"
-			health_check_configuration = {
+			health_check_configuration {
 				protocol = "TCP"
 				port = "80"
 				interval_seconds = 30

--- a/website/docs/r/vra_load_balancer.html.markdown
+++ b/website/docs/r/vra_load_balancer.html.markdown
@@ -2,41 +2,50 @@
 layout: "vra"
 page_title: "VMware vRealize Automation: vra_load_balancer"
 description: |-
-  Provides a VMware vRA vra_load_balancer resource.
+  Creates a vra_load_balancer resource.
 ---
+
 # Resource: vra_load_balancer
+
+Creates a VMware vRealize Automation load balancer resource.
+
 ## Example Usages
 
-This is an example of how to read a load balancer resource.
+The following example shows how to create a load balancer resource.
+
 
 ```hcl
-resource "vra_load_balancer" "my_load_balancer" {
-    name = "my-lb-%d"
-    project_id = vra_project.my-project.id
-    description = "load balancer description"
-    
-    targets {
-        machine_id = vra_machine.my_machine.id
-    }
+resource "vra_load_balancer" "this" {
+  name        = "my-load-balancer"
+  project_id  = vra_project.my-project.id
+  description = "My Load Balancer"
+  custom_properties = {
+    "edgeClusterRouterStateLink"  = "/resources/routers/<uuid>"
+    "tier0LogicalRouterStateLink" = "/resources/routers/<uuid>"
+  }
 
-    nics {
-        network_id = data.vra_network.my-network.id
-    }
+  targets {
+    machine_id = vra_machine.my_machine.id
+  }
 
-    routes {
-        protocol = "TCP"
-        port = "80"
-        member_protocol = "TCP"
-        member_port = "80"
-        health_check_configuration = {
-            protocol = "TCP"
-            port = "80"
-            interval_seconds = 30
-            timeout_seconds = 10
-            unhealthy_threshold = 2
-            healthy_threshold = 10
-        }
+  nics {
+    network_id = data.vra_network.my-network.id
+  }
+
+  routes {
+    protocol        = "TCP"
+    port            = "80"
+    member_protocol = "TCP"
+    member_port     = "80"
+    health_check_configuration {
+      protocol            = "TCP"
+      port                = "80"
+      interval_seconds    = 30
+      timeout_seconds     = 10
+      unhealthy_threshold = 2
+      healthy_threshold   = 10
     }
+  }
 }
 ```
 


### PR DESCRIPTION
Updates the `health_check_configuration` in the `vra_load_balancer` to show the use of `TypeSet` vs 'TypeList`.

More updates to docs and examples may be needed based on https://github.com/vmware/terraform-provider-vra/commit/51b76df27516e5729ef2f82a0a1711ba86c2aa82.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>