### PR TITLE
Fix retrieving deployment resources

### DIFF
--- a/vra/resource.go
+++ b/vra/resource.go
@@ -60,14 +60,14 @@ func resourcesSchema() *schema.Schema {
 	}
 }
 
-func flattenResources(resources []*models.DeploymentResource) []map[string]interface{} {
-	if len(resources) == 0 {
-		return make([]map[string]interface{}, 0)
+func flattenResources(deploymentResources *models.PageOfDeploymentResource) []map[string]interface{} {
+	resources := make([]map[string]interface{}, 0)
+
+	if deploymentResources == nil {
+		return resources
 	}
 
-	configResources := make([]map[string]interface{}, 0, len(resources))
-
-	for _, value := range resources {
+	for _, value := range deploymentResources.Content {
 		helper := make(map[string]interface{})
 
 		helper["created_at"] = value.CreatedAt.String()
@@ -83,10 +83,10 @@ func flattenResources(resources []*models.DeploymentResource) []map[string]inter
 		propertiesSlice, _ := json.Marshal(value.Properties)
 		helper["properties_json"] = string(propertiesSlice)
 
-		configResources = append(configResources, helper)
+		resources = append(resources, helper)
 	}
 
-	return configResources
+	return resources
 }
 
 //func expandResources(configResources []interface{}) []*models.Resource {

--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -407,7 +407,17 @@ func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	d.Set("project_id", deployment.ProjectID)
 
-	if err := d.Set("resources", flattenResources(deployment.Resources)); err != nil {
+	getResourcesResp, err := apiClient.Deployments.GetDeploymentResourcesUsingGET2(
+		deployments.NewGetDeploymentResourcesUsingGET2Params().
+			WithDeploymentID(strfmt.UUID(id)).
+			WithExpand([]string{"currentRequest"}).
+			WithAPIVersion(withString(DeploymentsAPIVersion)).
+			WithTimeout(IncreasedTimeOut))
+	if err != nil {
+		return diag.Errorf("error retrieving deployment resources - error: %#v", err)
+	}
+
+	if err := d.Set("resources", flattenResources(getResourcesResp.GetPayload())); err != nil {
 		return diag.Errorf("error setting resources in deployment - error: %#v", err)
 	}
 


### PR DESCRIPTION
Deployments API version '2020-08-25' only returns the summary of resources. In order to get all properties from resources, we have to make an explicit call. Fixes #427.

Signed-off-by: Ferran Rodenas <rodenasf@vmware.com>