### PR TITLE
Add blueprint schema fetch if catalog version not available during deployment update

### DIFF
--- a/examples/cloud_account_vsphere/main.tf
+++ b/examples/cloud_account_vsphere/main.tf
@@ -4,7 +4,7 @@ provider "vra" {
   insecure      = var.insecure // false for vRA Cloud and true for vRA 8.0
 }
 
- Required for vRA Cloud, Optional for vRA 8.X
+# Required for vRA Cloud, Optional for vRA 8.X
 data "vra_data_collector" "dc" {
   count = var.datacollector != "" ? 1 : 0
   name  = var.datacollector

--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -913,14 +913,9 @@ func runDeploymentUpdateAction(ctx context.Context, d *schema.ResourceData, apiC
 				log.Printf("Error while getting catalog item inputs. Checking with blueprint instead")
 
 				if blueprintID != "" {
-					blueprintVersion := ""
-					if v, ok := d.GetOk("blueprint_version"); ok {
-						blueprintVersion = v.(string)
-					}
-
 					// Get the schema from blueprint to convert the provided input values
 					// to the type defined in the schema.
-					inputs, err = getBlueprintInputsByType(apiClient, blueprintID, blueprintVersion, v)
+					inputs, err = getBlueprintInputsByType(apiClient, blueprintID, catalogItemVersion, v)
 					if err != nil {
 						return err
 					}

--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -893,6 +893,8 @@ func runDeploymentUpdateAction(ctx context.Context, d *schema.ResourceData, apiC
 		blueprintID = v.(string)
 	}
 
+	log.Printf("Checking values before any update [catalog_item_id]: %s, [blueprint_id]: %s.", catalogItemID, blueprintID)
+
 	// If catalog_item_id is provided, get the catalog item schema deployment with the catalog item
 	if catalogItemID != "" {
 		catalogItemVersion := ""
@@ -905,7 +907,26 @@ func runDeploymentUpdateAction(ctx context.Context, d *schema.ResourceData, apiC
 			// to the type defined in the schema.
 			inputs, err = getCatalogItemInputsByType(apiClient, catalogItemID, catalogItemVersion, v)
 			if err != nil {
-				return err
+
+				// If the catalog item version is no longer available,
+				// check the inputs from the version in the blueprint
+				log.Printf("Error while getting catalog item inputs. Checking with blueprint instead")
+
+				if blueprintID != "" {
+					blueprintVersion := ""
+					if v, ok := d.GetOk("blueprint_version"); ok {
+						blueprintVersion = v.(string)
+					}
+
+					// Get the schema from blueprint to convert the provided input values
+					// to the type defined in the schema.
+					inputs, err = getBlueprintInputsByType(apiClient, blueprintID, blueprintVersion, v)
+					if err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
 			}
 		}
 	} else if blueprintID != "" {


### PR DESCRIPTION
This was done because if a catalog item version is no longer available, the update function returns a 404 error. However, the blueprint version still exists and contains all the useful information we need to update a deployment.

We had an issue where an already deployment resource where no longer terraform compliant if a catalog item version was no longer available.

Also commented a line in the cloud_account_vsphere example.

Signed-off-by: an2ane <antoine.berlon@gmail.com>