### PR TITLE
chore: deprecate `VRA7_` environmental variables

### DIFF
--- a/vra/provider.go
+++ b/vra/provider.go
@@ -2,11 +2,13 @@ package vra
 
 import (
 	"errors"
+	"os"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// Provider represents the VRA provider
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
@@ -32,15 +34,37 @@ func Provider() *schema.Provider {
 			},
 			"insecure": {
 				Type:        schema.TypeBool,
-				DefaultFunc: schema.EnvDefaultFunc("VRA7_INSECURE", nil),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"VRA_INSECURE", "VRA7_INSECURE"}, nil),
 				Optional:    true,
 				Description: "Specify whether to validate TLS certificates.",
+				ValidateDiagFunc: schema.SchemaValidateDiagFunc(func(_ interface{}, _ cty.Path) diag.Diagnostics {
+					var diags diag.Diagnostics
+					if envVar, ok := os.LookupEnv("VRA7_INSECURE"); ok && envVar != "" {
+						diags = append(diags, diag.Diagnostic{
+							Severity: diag.Warning,
+							Summary:  "Deprecated environment variable.",
+							Detail:   "'VRA7_INSECURE' is deprecated; use 'VRA_INSECURE'.",
+						})
+					}
+					return diags
+				}),
 			},
 			"reauthorize_timeout": {
 				Type:        schema.TypeString,
-				DefaultFunc: schema.EnvDefaultFunc("VRA7_REAUTHORIZE_TIMEOUT", nil),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"VRA_REAUTHORIZE_TIMEOUT", "VRA7_REAUTHORIZE_TIMEOUT"}, nil),
 				Optional:    true,
-				Description: "Specify timeout for how often to reauthorize the access token",
+				Description: "Specify timeout for how often to reauthorize the access token.",
+				ValidateDiagFunc: schema.SchemaValidateDiagFunc(func(_ interface{}, _ cty.Path) diag.Diagnostics {
+					var diags diag.Diagnostics
+					if envVar, ok := os.LookupEnv("VRA7_REAUTHORIZE_TIMEOUT"); ok && envVar != "" {
+						diags = append(diags, diag.Diagnostic{
+							Severity: diag.Warning,
+							Summary:  "Deprecated environment variable.",
+							Detail:   "'VRA7_REAUTHORIZE_TIMEOUT' is deprecated; use 'VRA_REAUTHORIZE_TIMEOUT'.",
+						})
+					}
+					return diags
+				}),
 			},
 			"api_timeout": {
 				Type:        schema.TypeInt,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -65,12 +65,12 @@ Note that in all of the examples you will need to update attributes - such as `u
 
 The following arguments are used to configure the Terraform Provider for VMware Aria Automation:
 
-* `url` - (Required) This is the URL to the VMware Aria Automation endpoint. Can also be specified with the `VRA_URL` environment variable.
-* `access_token` - (Optional) This is the access token used to create an API refresh token. Can also be specified with the `VRA_ACCESS_TOKEN` environment variable.
-* `refresh_token` - (Optional) This is a refresh token used for API access that has been pre-generated. One of `access_token` or `refresh_token` is required. Can also be specified with the `VRA_REFRESH_TOKEN` environment variable.
-* `insecure` - (Optional) This specifies whether if the TLS certificates are validated. Can also be specified with the `VRA7_INSECURE` environment variable.
-* `reauthorize_timeout` - (Optional) This specifies the timeout for how often to reauthorize the access token. Can also be specified with the `VRA7_REAUTHORIZE_TIMEOUT` environment variable.
-* `api_timeout` - (Optional) This specifies the timeout in seconds for API operations. Can also be specified with the `VRA_API_TIMEOUT` environment variable.
+- `url` - (Required) This is the URL to the VMware Aria Automation endpoint. Can also be specified with the `VRA_URL` environment variable.
+- `access_token` - (Optional) This is the access token used to create an API refresh token. Can also be specified with the `VRA_ACCESS_TOKEN` environment variable.
+- `refresh_token` - (Optional) This is a refresh token used for API access that has been pre-generated. One of `access_token` or `refresh_token` is required. Can also be specified with the `VRA_REFRESH_TOKEN` environment variable.
+- `insecure` - (Optional) This specifies whether if the TLS certificates are validated. Can also be specified with the `VRA_INSECURE` environment variable.
+- `reauthorize_timeout` - (Optional) This specifies the timeout for how often to reauthorize the access token. Can also be specified with the `VRA_REAUTHORIZE_TIMEOUT` environment variable.
+- `api_timeout` - (Optional) This specifies the timeout in seconds for API operations. Can also be specified with the `VRA_API_TIMEOUT` environment variable.
 
 ## Bug Reports and Contributing
 


### PR DESCRIPTION
### Description

- Updates `reauthorize_timeout` to accept `VRA_INSECURE`, and `VRA7_INSECURE`. Use of `VRA7_INSECURE` will trigger the depreciation notice.
- Updates `insecure` to accept `VRA_REAUTHORIZE_TIMEOUT`, and `VRA7_REAUTHORIZE_TIMEOUT`. Use of `VRA7_REAUTHORIZE_TIMEOUT` will trigger the depreciation notice.
- Updates documentation.

### Reference

Closes #518