### PR TITLE
Bump golang to 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This provider supports VMware Aria Automation 8.
 
   For general information about Terraform, visit [developer.hashicorp.com][terraform-install] and [the project][terraform-github] on GitHub.
 
-- [Go 1.20][golang-install]
+- [Go 1.21][golang-install]
 
   Required if building the provider.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/terraform-provider-vra
 
-go 1.20
+go 1.21
 
 require (
 	github.com/go-openapi/runtime v0.25.0


### PR DESCRIPTION
Due to a critical CVE (CVE-2024-24790) which is not fixed in go 1.20 anymore the used go version has to be increased to at least 1.21.
The CVE scores a 9.8 in the national vulnerability database.
This PR just fixes the minimal used golang version to be 1.21 in the go.mod