### PR TITLE
feat: SCSI controller and unit number support, attach disks on build

### DIFF
--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -74,7 +74,7 @@ func resourceMachine() *schema.Resource {
 			"attach_disks_before_boot": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "By default, disks are attached after the VM has been built as FCDs cannot be attached to machine as day 0",
+				Description: "By default, disks are attached after the machine has been built. FCDs cannot be attached to machine as a day 0 task.",
 			},
 			"disks": {
 				Type:        schema.TypeSet,

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -516,8 +516,8 @@ func attachAndDetachDisks(ctx context.Context, d *schema.ResourceData, apiClient
 				Name:          diskToAttach["name"].(string),
 			}
 
-			if v_scsi_controller, ok_scsi_controller := diskToAttach["scsi_controller"].(string); ok_scsi_controller && v_scsi_controller != "" {
-				if v_unit_number, ok_unit_number := diskToAttach["unit_number"].(string); ok_unit_number && v_unit_number != "" {
+			if vScsiController, okScsiController := diskToAttach["scsi_controller"].(string); okScsiController && vScsiController != "" {
+				if vUnitNumber, okUnitNumber := diskToAttach["unit_number"].(string); okUnitNumber && vUnitNumber != "" {
 					diskAttachmentSpecification.DiskAttachmentProperties = map[string]string{"scsiController": diskToAttach["scsi_controller"].(string), "unitNumber": diskToAttach["unit_number"].(string)}
 				}
 			}
@@ -655,8 +655,8 @@ func expandDisks(configDisks []interface{}) []*models.DiskAttachmentSpecificatio
 			BlockDeviceID: withString(diskMap["block_device_id"].(string)),
 		}
 
-		if v_scsi_controller, ok_scsi_controller := diskMap["scsi_controller"].(string); ok_scsi_controller && v_scsi_controller != "" {
-			if v_unit_number, ok_unit_number := diskMap["unit_number"].(string); ok_unit_number && v_unit_number != "" {
+		if vScsiController, okScsiController := diskMap["scsi_controller"].(string); okScsiController && vScsiController != "" {
+			if vUnitNumber, okUnitNumber := diskMap["unit_number"].(string); okUnitNumber && vUnitNumber != "" {
 				disk.DiskAttachmentProperties = map[string]string{"scsiController": diskMap["scsi_controller"].(string), "unitNumber": diskMap["unit_number"].(string)}
 			}
 		}

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -105,7 +105,7 @@ func resourceMachine() *schema.Resource {
 						"unit_number": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "The unit number of the scsi controller. Example: 2",
+							Description: "The unit number of the SCSI controller. Example: 2",
 						},
 					},
 				},

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -100,7 +100,7 @@ func resourceMachine() *schema.Resource {
 						"scsi_controller": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "The id of the scsi controller. Example: SCSI_Controller_0",
+							Description: "The id of the SCSI controller. Example: SCSI_Controller_0",
 						},
 						"unit_number": {
 							Type:        schema.TypeString,

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -71,6 +71,11 @@ func resourceMachine() *schema.Resource {
 				Computed:    true,
 				Description: "The id of the deployment that is associated with this resource.",
 			},
+			"attach_disks_before_boot": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "By default, disks are attached after the VM has been built as FCDs cannot be attached to machine as day 0",
+			},
 			"disks": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -91,6 +96,16 @@ func resourceMachine() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The id of the existing block device.",
+						},
+						"scsi_controller": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The id of the scsi controller. Example: SCSI_Controller_0",
+						},
+						"unit_number": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The unit number of the scsi controller. Example: 2",
 						},
 					},
 				},
@@ -115,6 +130,16 @@ func resourceMachine() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "The id of the existing block device.",
+						},
+						"scsi_controller": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The id of the scsi controller. Example: SCSI_Controller_0",
+						},
+						"unit_number": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The unit number of the scsi controller. Example: 2",
 						},
 					},
 				},
@@ -212,6 +237,10 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 		ImageDiskConstraints: imageDiskConstraints,
 	}
 
+	if v, ok := d.GetOk("attach_disks_before_boot"); ok && v == true {
+		machineSpecification.Disks = disks
+	}
+
 	image, imageRef := "", ""
 	if v, ok := d.GetOk("image"); ok {
 		image = v.(string)
@@ -271,26 +300,28 @@ func resourceMachineCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	// As FCDs cannot be attached to machine as day 0, the machine is first provisioned without requested disks attached.
 	// Once the machine provisioning is complete, disks are attached one by one as day-2 action.
-	for i, diskAttachmentSpecification := range disks {
-		log.Printf("Attaching the disk %v of %v (disk id: %v) to vra_machine resource %v", i+1, len(disks), diskAttachmentSpecification.BlockDeviceID, d.Get("name"))
+	if v, ok := d.GetOk("attach_disks_before_boot"); !ok || v != true {
+		for i, diskAttachmentSpecification := range disks {
+			log.Printf("Attaching the disk %v of %v (disk id: %v) to vra_machine resource %v", i+1, len(disks), diskAttachmentSpecification.BlockDeviceID, d.Get("name"))
 
-		attachMachineDiskOk, err := apiClient.Disk.AttachMachineDisk(disk.NewAttachMachineDiskParams().WithID(machineID).WithBody(diskAttachmentSpecification))
+			attachMachineDiskOk, err := apiClient.Disk.AttachMachineDisk(disk.NewAttachMachineDiskParams().WithID(machineID).WithBody(diskAttachmentSpecification))
 
-		if err != nil {
-			return diag.FromErr(err)
-		}
+			if err != nil {
+				return diag.FromErr(err)
+			}
 
-		stateChangeFunc := retry.StateChangeConf{
-			Delay:      5 * time.Second,
-			Pending:    []string{models.RequestTrackerStatusINPROGRESS},
-			Refresh:    machineStateRefreshFunc(*apiClient, *attachMachineDiskOk.Payload.ID),
-			Target:     []string{models.RequestTrackerStatusFINISHED},
-			Timeout:    d.Timeout(schema.TimeoutCreate),
-			MinTimeout: 5 * time.Second,
-		}
+			stateChangeFunc := retry.StateChangeConf{
+				Delay:      5 * time.Second,
+				Pending:    []string{models.RequestTrackerStatusINPROGRESS},
+				Refresh:    machineStateRefreshFunc(*apiClient, *attachMachineDiskOk.Payload.ID),
+				Target:     []string{models.RequestTrackerStatusFINISHED},
+				Timeout:    d.Timeout(schema.TimeoutCreate),
+				MinTimeout: 5 * time.Second,
+			}
 
-		if _, err := stateChangeFunc.WaitForStateContext(ctx); err != nil {
-			return diag.FromErr(err)
+			if _, err := stateChangeFunc.WaitForStateContext(ctx); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 
@@ -485,6 +516,12 @@ func attachAndDetachDisks(ctx context.Context, d *schema.ResourceData, apiClient
 				Name:          diskToAttach["name"].(string),
 			}
 
+			if v_scsi_controller, ok_scsi_controller := diskToAttach["scsi_controller"].(string); ok_scsi_controller && v_scsi_controller != "" {
+				if v_unit_number, ok_unit_number := diskToAttach["unit_number"].(string); ok_unit_number && v_unit_number != "" {
+					diskAttachmentSpecification.DiskAttachmentProperties = map[string]string{"scsiController": diskToAttach["scsi_controller"].(string), "unitNumber": diskToAttach["unit_number"].(string)}
+				}
+			}
+
 			attachMachineDiskOk, err := apiClient.Disk.AttachMachineDisk(disk.NewAttachMachineDiskParams().WithID(id).WithBody(&diskAttachmentSpecification))
 
 			if err != nil {
@@ -618,6 +655,12 @@ func expandDisks(configDisks []interface{}) []*models.DiskAttachmentSpecificatio
 			BlockDeviceID: withString(diskMap["block_device_id"].(string)),
 		}
 
+		if v_scsi_controller, ok_scsi_controller := diskMap["scsi_controller"].(string); ok_scsi_controller && v_scsi_controller != "" {
+			if v_unit_number, ok_unit_number := diskMap["unit_number"].(string); ok_unit_number && v_unit_number != "" {
+				disk.DiskAttachmentProperties = map[string]string{"scsiController": diskMap["scsi_controller"].(string), "unitNumber": diskMap["unit_number"].(string)}
+			}
+		}
+
 		if v, ok := diskMap["name"].(string); ok && v != "" {
 			disk.Name = v
 		}
@@ -673,6 +716,14 @@ func filterDisks(disksConfig []interface{}, blockDevices []*models.BlockDevice) 
 
 				if diskConfigMap["description"].(string) != "" {
 					helper["description"] = blockDevice.Description
+				}
+
+				if diskConfigMap["scsi_controller"].(string) != "" {
+					helper["scsi_controller"] = diskConfigMap["scsi_controller"]
+				}
+
+				if diskConfigMap["unit_number"].(string) != "" {
+					helper["unit_number"] = diskConfigMap["unit_number"]
 				}
 
 				disks = append(disks, helper)

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -134,7 +134,7 @@ func resourceMachine() *schema.Resource {
 						"scsi_controller": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "The id of the scsi controller. Example: SCSI_Controller_0",
+							Description: "The id of the SCSI controller. Example: SCSI_Controller_0",
 						},
 						"unit_number": {
 							Type:        schema.TypeString,

--- a/vra/resource_machine.go
+++ b/vra/resource_machine.go
@@ -139,7 +139,7 @@ func resourceMachine() *schema.Resource {
 						"unit_number": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "The unit number of the scsi controller. Example: 2",
+							Description: "The unit number of the SCSI controller. Example: 2",
 						},
 					},
 				},

--- a/website/docs/r/vra_machine.html.markdown
+++ b/website/docs/r/vra_machine.html.markdown
@@ -142,7 +142,7 @@ Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandato
 
     * `scsi_controller` - The id of the SCSI controller (_e.g_., `SCSI_Controller_0`.)
 
-    * `unit_number` - The unit number of the scsi controller. Example: 2
+    * `unit_number` - The unit number of the SCSI controller (_e.g_., `2`.)
 
 * `external_id` - External entity ID on the provider side.
 

--- a/website/docs/r/vra_machine.html.markdown
+++ b/website/docs/r/vra_machine.html.markdown
@@ -130,6 +130,8 @@ Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandato
 
 * `created_at` - Date when the entity was created. Date and time format is ISO 8601 and UTC.
 
+* `attach_disks_before_boot` - By default, disks are attached after the VM has been built as FCDs cannot be attached to machine as day 0
+
 * `disks_list` - List of all disks attached to a machine including boot disk, and additional block devices attached using the disks attribute.
 
     * `block_device_id` - ID of existing block device.
@@ -137,6 +139,10 @@ Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandato
     * `description` - Human-friendly description.
 
     * `name` - Human-friendly block-device name used as an identifier in APIs that support this option.
+
+    * `scsi_controller` - The id of the scsi controller. Example: SCSI_Controller_0
+
+    * `unit_number` - The unit number of the scsi controller. Example: 2
 
 * `external_id` - External entity ID on the provider side.
 

--- a/website/docs/r/vra_machine.html.markdown
+++ b/website/docs/r/vra_machine.html.markdown
@@ -130,7 +130,7 @@ Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandato
 
 * `created_at` - Date when the entity was created. Date and time format is ISO 8601 and UTC.
 
-* `attach_disks_before_boot` - By default, disks are attached after the VM has been built as FCDs cannot be attached to machine as day 0
+* `attach_disks_before_boot` - By default, disks are attached after the VM has been built as FCDs cannot be attached to machine as day 0.
 
 * `disks_list` - List of all disks attached to a machine including boot disk, and additional block devices attached using the disks attribute.
 

--- a/website/docs/r/vra_machine.html.markdown
+++ b/website/docs/r/vra_machine.html.markdown
@@ -140,7 +140,7 @@ Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandato
 
     * `name` - Human-friendly block-device name used as an identifier in APIs that support this option.
 
-    * `scsi_controller` - The id of the scsi controller. Example: SCSI_Controller_0
+    * `scsi_controller` - The id of the SCSI controller (_e.g_., `SCSI_Controller_0`.)
 
     * `unit_number` - The unit number of the scsi controller. Example: 2
 


### PR DESCRIPTION
- Feature added based on request: https://github.com/vmware/terraform-provider-vra/issues/538 To be able to specify scsi controller and unit for block device attach
- Added support for attaching disks on build

Closes #538