### PR TITLE
feat: add `SPREAD_MEMORY` to `r/zone` `placement_policy`

### DIFF
--- a/vra/resource_zone_test.go
+++ b/vra/resource_zone_test.go
@@ -172,7 +172,7 @@ func TestAccVRAZoneInvalidPlacementPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccCheckVRAZoneConfigInvalidPlacementPolicy(),
-				ExpectError: regexp.MustCompile("\"placement_policy\" must be one of 'DEFAULT', 'SPREAD', 'BINPACK'"),
+				ExpectError: regexp.MustCompile("\"placement_policy\" must be one of 'DEFAULT', 'BINPACK', 'SPREAD', 'SPREAD_MEMORY'"),
 			},
 		},
 	})

--- a/website/docs/d/vra_zone.html.markdown
+++ b/website/docs/d/vra_zone.html.markdown
@@ -47,7 +47,7 @@ A zone data source supports the following arguments:
 
 * `owner` - Email of the user that owns the entity.
 
-* `placement_policy` - The placement policy for the zone. One of `DEFAULT`, `SPREAD` or `BINPACK`.
+* `placement_policy` - The placement policy for the zone. One of `DEFAULT`, `BINPACK`, `SPREAD` or `SPREAD_MEMORY`.
 
 * `tags` - A set of tag keys and optional values that were set on this resource:
   * `key` - Tag’s key.

--- a/website/docs/r/vra_zone.html.markdown
+++ b/website/docs/r/vra_zone.html.markdown
@@ -43,7 +43,7 @@ A zone resource supports the following arguments:
 
 * `name` - (Required) A human-friendly name used as an identifier for the zone resource instance.
 
-* `placement_policy` - (Optional) The placement policy for the zone. One of `DEFAULT`, `SPREAD` or `BINPACK`. Default is `DEFAULT`.
+* `placement_policy` - (Optional) The placement policy for the zone. One of `DEFAULT`, `BINPACK`, `SPREAD` or `SPREAD_MEMORY`. Default is `DEFAULT`.
 
 * `region_id` - (Required) The id of the region for which this zone is created.
 


### PR DESCRIPTION
### Description

- Adds `SPREAD_MEMORY` to `r/zone` `placement_policy`.
- Refactors to use constants for the placement policies and a var for the validation.

### Tests

```shell
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestAccVRAZoneInvalidPlacementPolicy$ github.com/vmware/terraform-provider-vra/vra

=== RUN   TestAccVRAZoneInvalidPlacementPolicy
    /Users/johnsonryan/Downloads/terraform-provider-vra/vra/resource_zone_test.go:168: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccVRAZoneInvalidPlacementPolicy (0.00s)
PASS
ok      github.com/vmware/terraform-provider-vra/vra    0.946s
```

### Reference

Closes #571 