### PR TITLE
feat: add `d/vra_load_balancer`

### DIFF
--- a/docs/data-sources/vra_load_balancer.md
+++ b/docs/data-sources/vra_load_balancer.md
@@ -1,0 +1,100 @@
+---
+page_title: "VMware vRealize Automation: vra_load_balancer"
+description: |-
+  Provides a data source for a load balancer resource.
+---
+
+# Data Source: vra_load_balancer
+
+Provides a data source to retrieve a `vra_load_balancer`.
+
+## Example Usage
+
+This is an example of how to get a load balancer resource by its id.
+
+```hcl
+data "vra_load_balancer" "this" {
+  id = "load-balancer-id"
+}
+
+output "load_balancer_name" {
+  value = data.vra_load_balancer.this.name
+}
+
+## Argument Reference
+
+* `id` - (Required) The id of the load balancer.
+
+## Attribute Reference
+
+* `address` - Primary address allocated or in use by this load balancer. The address could be an in the form of a publicly resolvable DNS name or an IP address.
+
+* `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
+
+* `custom_properties` - A set of custom properties that were set on this resource instance. This is a key-value pair where the key is a string and the value can be any string.
+
+* `description` - Description of the load balancer.
+
+* `deployment_id` - The id of the deployment that is associated with this resource.
+
+* `external_id` - External entity Id on the provider side.
+
+* `external_region_id` - The external regionId of the resource.
+
+* `external_zone_id` - The external regionId of the resource.
+
+* `links` - HATEOAS of the entity.
+
+* `name` - Name of the load balancer.
+
+* `organization_id` - The id of the organization this entity belongs to.
+
+* `owner` - Email of the user that owns the entity.
+
+* `project_id` - The id of the project that is associated with this resource.
+
+* `routes` - The load balancer route configuration regarding ports and protocols.
+
+    * `algorithm` - Algorithm employed for load balancing.
+
+    * `algorithm_parameters` - Parameters need for load balancing algorithm.Use newline to separate multiple parameters.
+
+    * `health_check_configuration` - Load balancer health check configuration.
+
+        * `healthy_threshold` - Number of consecutive successful checks before considering a particular back-end instance as healthy.
+
+        * `http_method` - HTTP or HTTPS method to use when sending a health check request.
+
+        * `interval_seconds` - Interval (in seconds) at which the health checks will be performed.
+
+        * `passive_monitor` - Enable passive monitor mode. This setting only applies to NSX-T.
+
+        * `port` - Port on the back-end instance machine to use for the health check.
+
+        * `protocol` - The protocol used for the health check.
+
+        * `request_body` - Request body. Used by HTTP, HTTPS, TCP, UDP.
+
+        * `response_body` - Expected response body. Used by HTTP, HTTPS, TCP, UDP.
+
+        * `timeout_seconds` - Timeout (in seconds) to wait for a response from the back-end instance.
+
+        * `unhealthy_threashold` - Number of consecutive check failures before considering a particular back-end instance as unhealthy.
+
+        * `urlPath` - URL path on the back-end instance against which a request will be performed for the health check. Useful when the health check protocol is HTTP/HTTPS.
+
+    * `member_port` - Member port where the traffic is routed to.
+
+    * `member_protocol` - The protocol of the member traffic.
+
+    * `port` - Port which the load balancer is listening to.
+
+    * `protocol` - The protocol of the incoming load balancer requests.
+
+* `targets` - A list of links to target load balancer pool members. Links can be to either a machine or a machine's network interface.
+
+* `tags` - A set of tag keys and optional values that were set on this resource instance.
+  * `key` - Tag’s key.
+  * `value` - Tag’s value.
+
+* `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/vra/data_source_load_balancer.go
+++ b/vra/data_source_load_balancer.go
@@ -1,0 +1,128 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package vra
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/vra-sdk-go/pkg/client/load_balancer"
+)
+
+func dataSourceLoadBalancer() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceLoadBalancerRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nics": nicsSchema(false),
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"routes": routesSchema(false),
+			"custom_properties": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deployment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"internet_facing": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"tags":    tagsSchema(),
+			"targets": LoadBalancerTargetSchema(),
+			"address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external_zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": linksSchema(),
+			"organization_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceLoadBalancerRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	apiClient := m.(*Client).apiClient
+
+	id := d.Get("id").(string)
+	resp, err := apiClient.LoadBalancer.GetLoadBalancer(load_balancer.NewGetLoadBalancerParams().WithID(id))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	loadBalancer := *resp.Payload
+	d.SetId(id)
+	d.Set("address", loadBalancer.Address)
+	d.Set("created_at", loadBalancer.CreatedAt)
+	d.Set("custom_properties", loadBalancer.CustomProperties)
+	d.Set("description", loadBalancer.Description)
+	d.Set("deployment_id", loadBalancer.DeploymentID)
+	d.Set("external_id", loadBalancer.ExternalID)
+	d.Set("external_region_id", loadBalancer.ExternalRegionID)
+	d.Set("external_zone_id", loadBalancer.ExternalZoneID)
+	d.Set("name", loadBalancer.Name)
+	d.Set("organization_id", loadBalancer.OrgID)
+	d.Set("owner", loadBalancer.Owner)
+	d.Set("project_id", loadBalancer.ProjectID)
+	d.Set("updated_at", loadBalancer.UpdatedAt)
+
+	if err := d.Set("tags", flattenTags(loadBalancer.Tags)); err != nil {
+		return diag.Errorf("error setting load balancer tags - error: %v", err)
+	}
+	if err := d.Set("routes", flattenRoutes(loadBalancer.Routes)); err != nil {
+		return diag.Errorf("error setting load balancer routes - error: %v", err)
+	}
+
+	if err := d.Set("links", flattenLinks(loadBalancer.Links)); err != nil {
+		return diag.Errorf("error setting load balancer links - error: %#v", err)
+	}
+
+	log.Printf("Finished reading the vra_load_balancer data source with id %s", d.Get("id"))
+	return nil
+}

--- a/vra/data_source_load_balancer_test.go
+++ b/vra/data_source_load_balancer_test.go
@@ -1,0 +1,186 @@
+// © Broadcom. All Rights Reserved.
+// The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package vra
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccVRALoadBalancerDataSource(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheckLoadBalancerDataSource(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVRALoadBalancerDataSourceConfig(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vra_load_balancer.test", "name", fmt.Sprintf("my-lb-%d", rInt)),
+					resource.TestMatchResourceAttr("data.vra_load_balancer.test", "id", regexp.MustCompile("^lb-")),
+					resource.TestCheckResourceAttr("data.vra_load_balancer.test", "routes.#", "1"),
+					resource.TestCheckResourceAttr("data.vra_load_balancer.test", "nics.#", "1"),
+					resource.TestCheckResourceAttr("data.vra_load_balancer.test", "targets.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVRALoadBalancerDataSourceConfig(rInt int) string {
+	return testAccCheckVRALoadBalancerDataSource(rInt) + fmt.Sprintf(`
+resource "vra_load_balancer" "test" {
+	name        = "my-lb-%d"
+	project_id  = vra_project.my-project.id
+	description = "load balancer description"
+
+	targets {
+		machine_id = vra_machine.my_machine.id
+	}
+
+	nics {
+		network_id = data.vra_network.my-network.id
+	}
+
+	routes {
+		protocol        = "TCP"
+		port            = "80"
+		member_protocol = "TCP"
+		member_port     = "80"
+		health_check_configuration = {
+			protocol            = "TCP"
+			port                = "80"
+			interval_seconds    = 30
+			timeout_seconds     = 10
+			unhealthy_threshold = 2
+			healthy_threshold   = 10
+		}
+	}
+}
+
+data "vra_load_balancer" "test" {
+	id = vra_load_balancer.test.id
+}
+`, rInt)
+}
+
+func testAccPreCheckLoadBalancerDataSource(t *testing.T) {
+	if os.Getenv("VRA_AWS_CLOUD_ACCOUNT_NAME") == "" {
+		t.Fatal("VRA_AWS_CLOUD_ACCOUNT_NAME must be set for acceptance tests")
+	}
+	if os.Getenv("VRA_FABRIC_NETWORK") == "" {
+		t.Fatal("VRA_FABRIC_NETWORK must be set for acceptance tests")
+	}
+	if os.Getenv("VRA_REGION") == "" {
+		t.Fatal("VRA_REGION must be set for acceptance tests")
+	}
+	if os.Getenv("VRA_IMAGE") == "" {
+		t.Fatal("VRA_IMAGE must be set for acceptance tests")
+	}
+	if os.Getenv("VRA_FLAVOR") == "" {
+		t.Fatal("VRA_FLAVOR must be set for acceptance tests")
+	}
+}
+
+func testAccCheckVRALoadBalancerDataSource(rInt int) string {
+	name := os.Getenv("VRA_AWS_CLOUD_ACCOUNT_NAME")
+	fabricNetwork := os.Getenv("VRA_FABRIC_NETWORK")
+	region := os.Getenv("VRA_REGION")
+	image := os.Getenv("VRA_IMAGE")
+	flavor := os.Getenv("VRA_FLAVOR")
+	return fmt.Sprintf(`
+
+data "vra_cloud_account_aws" "my-cloud-account" {
+	name = "%s"
+}
+
+data "vra_region" "my-region" {
+	cloud_account_id = data.vra_cloud_account_aws.my-cloud-account.id
+	region           = "%s"
+}
+
+resource "vra_zone" "my-zone" {
+	name        = "my-zone-%d"
+	description = "description my-vra-zone"
+	region_id   = data.vra_region.my-region.id
+}
+
+resource "vra_project" "my-project" {
+	name        = "my-project-%d"
+	description = "test project"
+	zone_assignments {
+		zone_id       = vra_zone.my-zone.id
+		priority      = 1
+		max_instances = 2
+	}
+}
+
+data "vra_fabric_network" "subnet" {
+	filter = "name eq '%s'"
+}
+
+resource "vra_network_profile" "my-network-profile" {
+	name        = "my-network-profile-%d"
+	description = "test network profile"
+	region_id   = data.vra_region.my-region.id
+
+	fabric_network_ids = [
+		data.vra_fabric_network.subnet.id,
+	]
+
+	isolation_type = "NONE"
+
+	tags {
+		key   = "foo"
+		value = "bar"
+	}
+}
+
+data "vra_network" "my-network" {
+	name       = data.vra_fabric_network.subnet.name
+	depends_on = [vra_network_profile.my-network-profile]
+}
+
+resource "vra_image_profile" "my-image-profile" {
+	name        = "my-image-profile-%d"
+	description = "test image profile"
+	region_id   = data.vra_region.my-region.id
+
+	image_mapping {
+		name       = "image"
+		image_name = "%s"
+	}
+}
+
+resource "vra_flavor_profile" "my-flavor-profile" {
+	name        = "my-flavor-profile-%d"
+	description = "my flavor"
+	region_id   = data.vra_region.my-region.id
+	flavor_mapping {
+		name          = "flavor"
+		instance_type = "%s"
+	}
+}
+
+resource "vra_machine" "my-machine" {
+	name        = "my-machine-%d"
+	description = "test machine updated"
+	project_id  = vra_project.my-project.id
+	image       = "image"
+	flavor      = "flavor"
+
+	tags {
+		key   = "foo"
+		value = "bar"
+	}
+}
+`, name, region, rInt, rInt, fabricNetwork, rInt, rInt, image, rInt, flavor, rInt)
+}

--- a/vra/provider.go
+++ b/vra/provider.go
@@ -110,6 +110,7 @@ func Provider() *schema.Provider {
 			"vra_fabric_storage_policy_vsphere": dataSourceFabricStoragePolicyVsphere(),
 			"vra_image":                         dataSourceImage(),
 			"vra_image_profile":                 dataSourceImageProfile(),
+			"vra_load_balancer":                 dataSourceLoadBalancer(),
 			"vra_machine":                       dataSourceMachine(),
 			"vra_network":                       dataSourceNetwork(),
 			"vra_network_domain":                dataSourceNetworkDomain(),

--- a/vra/resource_load_balancer_test.go
+++ b/vra/resource_load_balancer_test.go
@@ -252,8 +252,8 @@ func testAccCheckVRALoadBalancerConfig(rInt int) string {
 
 	return testAccCheckVRALoadBalancer(rInt) + fmt.Sprintf(`
 	resource "vra_load_balancer" "my_load_balancer" {
-		name = "my-lb-%d"
-		project_id = vra_project.my-project.id
+		name        = "my-lb-%d"
+		project_id  = vra_project.my-project.id
 		description = "load balancer description"
 
 		targets {
@@ -265,17 +265,17 @@ func testAccCheckVRALoadBalancerConfig(rInt int) string {
 		}
 
 		routes {
-			protocol = "TCP"
-			port = "80"
+			protocol        = "TCP"
+			port            = "80"
 			member_protocol = "TCP"
-			member_port = "80"
+			member_port     = "80"
 			health_check_configuration = {
-				protocol = "TCP"
-				port = "80"
-				interval_seconds = 30
-				timeout_seconds = 10
+				protocol            = "TCP"
+				port                = "80"
+				interval_seconds    = 30
+				timeout_seconds     = 10
 				unhealthy_threshold = 2
-				healthy_threshold = 10
+				healthy_threshold   = 10
 			}
 		}
 		}`, rInt)


### PR DESCRIPTION
### Description

Adds support for `d/vra_load_balancer`.

Updates the test resource whitespace for allignment with `terraform fmt`.

### Tests

```shell
=== RUN   TestAccVRALoadBalancerDataSource
    data_source_load_balancer_test.go:22: Acceptance tests skipped unless env 'TF_ACC' set
--- SKIP: TestAccVRALoadBalancerDataSource (0.00s)

Test ignored.
PASS

Process finished with the exit code 0
```

### Reference

Closes #529