### PR TITLE
docs: markdown formatting

### DIFF
--- a/website/docs/d/vra_block_device.html.markdown
+++ b/website/docs/d/vra_block_device.html.markdown
@@ -1,5 +1,6 @@
----layout: "vra"
-page_title: "VMware vRealize Automation: vra_block_device"
+---
+layout: "vra"
+page_title: "VMware Aria Automation: vra_block_device"
 description: |-
   Provides a data lookup for vra_block_device.
 ---
@@ -18,7 +19,6 @@ This is an example of how to read a block device data source using its ID.
 data "vra_block_device" "this" {
   id = var.block_device_id
 }
-
 ```
 
 **Block device data source filter by name:**
@@ -29,7 +29,6 @@ This is an example of how to read a block device data source using its name.
 data "vra_block_device" "this" {
   filter = "name eq '${var.block_device_name}'"
 }
-
 ```
 
 ## Argument Reference
@@ -74,17 +73,14 @@ A block device data source supports the following attributes:
 
 * `persistent` - Indicates whether the block device survives a delete action.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `status` - Status of the block device.
 
-* `tags` - A set of tag keys and optional values that were set on this resource instance.
-example: `[ { "key" : "vmware.enumeration.type", "value": "nebs_block" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource instance. Example: `[ { "key" : "vmware.enumeration.type", "value": "nebs_block" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.
-
-
-
-

--- a/website/docs/d/vra_block_device_snapshot.html.markdown
+++ b/website/docs/d/vra_block_device_snapshot.html.markdown
@@ -1,22 +1,25 @@
----layout: "vra"
-page_title: "VMware vRealize Automation: vra_block_device_snapshots"
+---
+layout: "vra"
+page_title: "VMware Aria Automation: vra_block_device_snapshots"
 description: |-
   Provides a data lookup for vra_block_device_snapshots.
 ---
 
 # Data Source: vra_block_device_snapshots
+
 ## Example Usages
 
 This is an example of how to read a block device snapshots data source.
 
 **Block device snapshots data source by its id:**
+
 ```hcl
 
 data "vra_block_device_snapshot" "snapshot" {
   block_device_id = var.block_device_id
 }
-
 ```
+
 ## Argument Reference
 
 * `var.block_device_id` - (Required) The id of the existing block device.
@@ -29,9 +32,9 @@ data "vra_block_device_snapshot" "snapshot" {
 
 * `is_current` - Indicates whether this snapshot is the current snapshot on the block-device.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
-* `name` - A human-friendly name used as an identifier in APIs that support this option.  Only one of 'filter', 'id', 'name' or 'region_id' must be specified.
+* `name` - A human-friendly name used as an identifier in APIs that support this option.  Only one of `filter`, `id`, `name`, or `region_id` must be specified.
 
 * `org_id` - The id of the organization this entity belongs to.
 

--- a/website/docs/d/vra_blueprint.html.markdown
+++ b/website/docs/d/vra_blueprint.html.markdown
@@ -1,16 +1,16 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Data source vra_blueprint"
-description: A blueprint data source.
+page_title: "VMware Aria Automation: Data source vra_blueprint"
+description: A cloud template (blueprint) data source.
 ---
 
-# Data Source: vra\_blueprint
+# Data Source: vra_blueprint
 
-This data source provides information about a cloud template (blueprint) in vRA.
+This data source provides information about a cloud template (blueprint).
 
 ## Example Usages
 
-This is an example of how to get a vRA cloud template by its name.
+This is an example of how to get a cloud template by its name.
 
 ```hcl
 data "vra_blueprint" "this" {
@@ -18,7 +18,7 @@ data "vra_blueprint" "this" {
 }
 ```
 
-This is an example of how to get a vRA cloud template by its id.
+This is an example of how to get a cloud template by its id.
 
 ```hcl
 data "vra_blueprint" "this" {
@@ -32,14 +32,13 @@ data "vra_blueprint" "this" {
 
 * `name` - (Optional) Name of the cloud template. One of `id` or `name` must be provided.
 
-* `project_id` - (Optional) The id of the project to narrow the search while looking for cloud templates. 
-
+* `project_id` - (Optional) The id of the project to narrow the search while looking for cloud templates.
 
 ## Attribute Reference
 
 * `content` - Blueprint YAML content.
 
-* `content_source_id` - The id of the content source. 
+* `content_source_id` - The id of the content source.
 
 * `content_source_path` - Content source path.
 
@@ -61,13 +60,13 @@ data "vra_blueprint" "this" {
 
 * `project_name` - The name of the project the entity belongs to.
 
-* `self_link` - HATEOAS of the entity.
+* `self_link` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `request_scope_org` - Flag to indicate whether this blueprint can be requested from any project in the organization this entity belongs to.
 
 * `status` - Status of the cloud template. Supported values: `DRAFT`, `VERSIONED`, `RELEASED`.
 
-* `total_released_versions` - Total number of released versions. 
+* `total_released_versions` - Total number of released versions.
 
 * `total_versions` - Total number of versions.
 
@@ -78,12 +77,13 @@ data "vra_blueprint" "this" {
 * `valid` - Flag to indicate if the current content of the cloud template is valid.
 
 * `validation_messages` - List of validations messages.
-    * message - Validation message.
-    
-    * metadata - Validation metadata.
-    
-    * path - Validation path.
-    
-    * resource_name - Name of the resource.
-    
-    * type - Message type. Supported values: `INFO`, `WARNING`, `ERROR`.
+
+  * `message` - Validation message.
+
+  * `metadata` - Validation metadata.
+
+  * `path` - Validation path.
+
+  * `resource_name` - Name of the resource.
+
+  * `type` - Message type. Supported values: `INFO`, `WARNING`, `ERROR`.

--- a/website/docs/d/vra_blueprint_version.html.markdown
+++ b/website/docs/d/vra_blueprint_version.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Data source vra_blueprint_version"
+page_title: "VMware Aria Automation: Data source vra_blueprint_version"
 description: A blueprint version data source.
 ---
 
-# Data Source: vra\_blueprint\_version
+# Data Source: vra_blueprint_version
 
-This data source provides information about a cloud template (blueprint) version in vRA.
+This data source provides information about a cloud template (blueprint) version.
 
 ## Example Usages
 
@@ -22,7 +22,6 @@ data "vra_blueprint_version" "this" {
 * `blueprint_id` - (Required) Name of the cloud template. One of `id` or `name` must be provided.
 
 * `id` - (Required) The id of the cloud template version.
-
 
 ## Attribute Reference
 

--- a/website/docs/d/vra_catalog_item.html.markdown
+++ b/website/docs/d/vra_catalog_item.html.markdown
@@ -1,16 +1,16 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Data source vra_catalog_item"
+page_title: "VMware Aria Automation: Data source vra_catalog_item"
 description: A data source for a catalog item.
 ---
 
-# Data Source: vra\_catalog\_item
+# Data Source: vra_catalog_item
 
-This data source provides information about a catalog item in vRA.
+This data source provides information about a catalog item.
 
 ## Example Usages
 
-This is an example of how to get a vRA catalog item by its name.
+This is an example of how to get a catalog item by its name.
 
 ```hcl
 data "vra_catalog_item" "this" {
@@ -19,7 +19,7 @@ data "vra_catalog_item" "this" {
 }
 ```
 
-This is an example of how to get a vRA catalog item by its id.
+This is an example of how to get a catalog item by its id.
 
 ```hcl
 data "vra_catalog_item" "this" {
@@ -27,7 +27,6 @@ data "vra_catalog_item" "this" {
   expand_versions = true
 }
 ```
-
 
 ## Argument Reference
 
@@ -61,34 +60,34 @@ data "vra_catalog_item" "this" {
 
 * `projects` - List of associated projects that can be used for requesting this catalog item.
 
-    * `description` - A human friendly description.
-    
-    * `id` - Id of the entity.
-    
-    * `name` - Name of the entity.
-    
-    * `version` - Version of the entity, if applicable.
+  * `description` - A human friendly description.
 
-* `schema` - Json schema describing request parameters, a simplified version of http://json-schema.org/latest/json-schema-validation.html#rfc.section.5
+  * `id` - Id of the entity.
+
+  * `name` - Name of the entity.
+
+  * `version` - Version of the entity, if applicable.
+
+* `schema` - JSON schema describing request parameters, a simplified version of <http://json-schema.org/latest/json-schema-validation.html#rfc.section.5>
 
 * `source_id` - LibraryItem source ID.
 
 * `source_name` - LibraryItem source name.
 
-* `type` - 
+* `type` -
 
-    * `description` - A human friendly description.
-        
-    * `id` - Id of the entity.
-        
-    * `name` - Name of the entity.
-        
-    * `version` - Version of the entity, if applicable.
+  * `description` - A human friendly description.
+
+  * `id` - Id of the entity.
+
+  * `name` - Name of the entity.
+
+  * `version` - Version of the entity, if applicable.
 
 * `versions` - Catalog item versions.
 
-    * `created_at` - Date-time when catalog item version was created at.
-    
-    * `description` - A human-friendly description.
-    
-    * `id` - Id of the catalog item version.
+  * `created_at` - Date-time when catalog item version was created at.
+
+  * `description` - A human-friendly description.
+
+  * `id` - Id of the catalog item version.

--- a/website/docs/d/vra_catalog_item_entitlement.html.markdown
+++ b/website/docs/d/vra_catalog_item_entitlement.html.markdown
@@ -1,18 +1,18 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_catalog_item_entitlement"
+page_title: "VMware Aria Automation: vra_catalog_item_entitlement"
 description: A data source for catalog item entitlement.
 ---
 
-# Data Source: vra\_catalog\_item\_entitlement
+# Data Source: vra_catalog_item_entitlement
 
 > **Note**:  Deprecated - please use `vra_content_sharing_policy` instead.
 
-This data source provides information about a catalog item entitlement in vRA.
+This data source provides information about a catalog item entitlement.
 
 ## Example Usages
 
-This is an example of how to get a vRA catalog item entitlement by its id:
+This is an example of how to get a catalog item entitlement by its id:
 
 ```hcl
 data "vra_catalog_item_entitlement" "this" {
@@ -21,7 +21,7 @@ data "vra_catalog_item_entitlement" "this" {
 }
 ```
 
-This is an example of how to get a vRA catalog item entitlement by its catalog item id:
+This is an example of how to get a catalog item entitlement by its catalog item id:
 
 ```hcl
 data "vra_catalog_item_entitlement" "this" {
@@ -42,18 +42,18 @@ data "vra_catalog_item_entitlement" "this" {
 
 * `definition` - Represents a catalog item that is linked to a project via an entitlement.
 
-    * `description` - Description of the catalog item.
+  * `description` - Description of the catalog item.
 
-    * `icon_id` - Icon id of associated catalog item.
+  * `icon_id` - Icon id of associated catalog item.
 
-    * `id` - Id of the catalog item.
+  * `id` - Id of the catalog item.
 
-    * `name` - Name of the catalog item.
+  * `name` - Name of the catalog item.
 
-    * `number_of_items` - Number of items in the associated catalog source.
+  * `number_of_items` - Number of items in the associated catalog source.
 
-    * `source_name` - Catalog source name.
+  * `source_name` - Catalog source name.
 
-    * `source_type` - Catalog source type.
+  * `source_type` - Catalog source type.
 
-    * `type` - Content definition type.
+  * `type` - Content definition type.

--- a/website/docs/d/vra_catalog_source_blueprint.html.markdown
+++ b/website/docs/d/vra_catalog_source_blueprint.html.markdown
@@ -1,16 +1,16 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Data source vra_catalog_source_blueprint"
+page_title: "VMware Aria Automation: Data source vra_catalog_source_blueprint"
 description: A data source for catalog source of type cloud template (blueprint).
 ---
 
-# Data Source: vra\_catalog\_source\_blueprint
+# Data Source: vra_catalog_source_blueprint
 
-This data source provides information about a catalog source of type cloud template (blueprint) in vRA.
+This data source provides information about a catalog source of type cloud template (blueprint).
 
 ## Example Usages
 
-This is an example of how to get a vRA cloud template catalog source by its name.
+This is an example of how to get a cloud template catalog source by its name.
 
 ```hcl
 data "vra_catalog_source_blueprint" "this" {
@@ -18,7 +18,7 @@ data "vra_catalog_source_blueprint" "this" {
 }
 ```
 
-This is an example of how to get a vRA cloud template catalog source by its id.
+This is an example of how to get a cloud template catalog source by its id.
 
 ```hcl
 data "vra_catalog_source_blueprint" "this" {
@@ -26,14 +26,13 @@ data "vra_catalog_source_blueprint" "this" {
 }
 ```
 
-This is an example of how to get a vRA cloud template catalog source by the project id it is associated with.
+This is an example of how to get a cloud template catalog source by the project id it is associated with.
 
 ```hcl
 data "vra_catalog_source_blueprint" "this" {
   project_id = var.project_id
 }
 ```
-
 
 ## Argument Reference
 
@@ -42,7 +41,6 @@ data "vra_catalog_source_blueprint" "this" {
 * `name` - (Optional) Name of the catalog source. One of `id`, `name` or `project_id` must be provided.
 
 * `project_id` - (Optional) The id of the project.  One of `id`, `name` or `project_id` must be provided.
-
 
 ## Attribute Reference
 
@@ -66,6 +64,6 @@ data "vra_catalog_source_blueprint" "this" {
 
 * `last_import_started_at` - Time at which the last import was started at.
 
-* `last_updated_by` - The user that last updated the catalog source. 
+* `last_updated_by` - The user that last updated the catalog source.
 
 * `type_id` - Type of catalog source. Example: `blueprint`, `CFT`, etc.

--- a/website/docs/d/vra_catalog_source_entitlement.html.markdown
+++ b/website/docs/d/vra_catalog_source_entitlement.html.markdown
@@ -1,18 +1,18 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_catalog_source_entitlement"
+page_title: "VMware Aria Automation: vra_catalog_source_entitlement"
 description: A data source for catalog source entitlement.
 ---
 
-# Data Source: vra\_catalog\_source\_entitlement
+# Data Source: vra_catalog_source_entitlement
 
 > **Note**:  Deprecated - please use `vra_content_sharing_policy` instead.
 
-This data source provides information about a catalog source entitlement in vRA.
+This data source provides information about a catalog source entitlement.
 
 ## Example Usages
 
-This is an example of how to get a vRA catalog source entitlement by its id:
+This is an example of how to get a catalog source entitlement by its id:
 
 ```hcl
 data "vra_catalog_source_entitlement" "this" {
@@ -21,7 +21,7 @@ data "vra_catalog_source_entitlement" "this" {
 }
 ```
 
-This is an example of how to get a vRA catalog source entitlement by its catalog source id:
+This is an example of how to get a catalog source entitlement by its catalog source id:
 
 ```hcl
 data "vra_catalog_source_entitlement" "this" {
@@ -42,18 +42,18 @@ data "vra_catalog_source_entitlement" "this" {
 
 * `definition` - Represents a catalog source that is linked to a project via an entitlement.
 
-    * `description` - Description of the catalog source.
+  * `description` - Description of the catalog source.
 
-    * `icon_id` - Icon id of associated catalog source.
+  * `icon_id` - Icon id of associated catalog source.
 
-    * `id` - Id of the catalog source.
+  * `id` - Id of the catalog source.
 
-    * `name` - Name of the catalog source.
+  * `name` - Name of the catalog source.
 
-    * `number_of_items` - Number of items in the associated catalog source.
+  * `number_of_items` - Number of items in the associated catalog source.
 
-    * `source_name` - Catalog source name.
+  * `source_name` - Catalog source name.
 
-    * `source_type` - Catalog source type.
+  * `source_type` - Catalog source type.
 
-    * `type` - Content definition type.
+  * `type` - Content definition type.

--- a/website/docs/d/vra_cloud_account_aws.html.markdown
+++ b/website/docs/d/vra_cloud_account_aws.html.markdown
@@ -1,12 +1,13 @@
----layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_aws"
+---
+layout: "vra"
+page_title: "VMware Aria Automation: vra_cloud_account_aws"
 description: |-
   Provides a data lookup for vra_cloud_account_aws.
 ---
 
-# Data Source: vra\_cloud\_account\_aws
+# Data Source: vra_cloud_account_aws
 
-Provides a VMware vRA vra_cloud_account_aws data source.
+Provides a vra_cloud_account_aws data source.
 
 ## Example Usages
 
@@ -19,7 +20,6 @@ This is an example of how to read the cloud account data source using its id.
 data "vra_cloud_account_aws" "this" {
   id = var.vra_cloud_account_aws_id
 }
-
 ```
 
 **AWS cloud account data source by its name:**
@@ -31,10 +31,7 @@ This is an example of how to read the cloud account data source using its name.
 data "vra_cloud_account_aws" "this" {
   name = var.vra_cloud_account_aws_name
 }
-
 ```
-
-
 
 ## Argument Reference
 
@@ -52,7 +49,7 @@ The following arguments are supported for an AWS cloud account data source:
 
 * `description` - A human-friendly description.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
@@ -60,10 +57,10 @@ The following arguments are supported for an AWS cloud account data source:
 
 * `regions` - A set of region names that are enabled for this account.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "vmware", "value": "provider" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.
-

--- a/website/docs/d/vra_cloud_account_azure.html.markdown
+++ b/website/docs/d/vra_cloud_account_azure.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_azure"
+page_title: "VMware Aria Automation: vra_cloud_account_azure"
 description: |-
     Provides a data lookup for vra_cloud_account_azure.
 ---
 
-# Data Source: vra\_cloud\_account\_azure
+# Data Source: vra_cloud_account_azure
 
-Provides a VMware vRA vra_cloud_account_azure data source.
+Provides a vra_cloud_account_azure data source.
 
 ## Example Usages
 
@@ -20,7 +20,6 @@ This is an example of how to read the cloud account data source using its id.
 data "vra_cloud_account_azure" "this" {
   id = var.vra_cloud_account_azure_id
 }
-
 ```
 
 **Azure cloud account data source by its name:**
@@ -32,10 +31,7 @@ This is an example of how to read the cloud account data source using its name.
 data "vra_cloud_account_azure" "this" {
   name = var.vra_cloud_account_azure_name
 }
-
 ```
-
-
 
 ## Argument Reference
 
@@ -53,7 +49,7 @@ The following arguments are supported for an Azure cloud account data source:
 
 * `description` - A human-friendly description.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
@@ -63,9 +59,10 @@ The following arguments are supported for an Azure cloud account data source:
 
 * `subscription_id` - Azure Subscription ID.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "vmware", "value": "provider" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `tenant_id` - Azure Tenant ID.

--- a/website/docs/d/vra_cloud_account_gcp.html.markdown
+++ b/website/docs/d/vra_cloud_account_gcp.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_gcp"
+page_title: "VMware Aria Automation: vra_cloud_account_gcp"
 description: |-
     Provides a data lookup for vra_cloud_account_gcp.
 ---
 
-# Data Source: vra\_cloud\_account\_gcp
+# Data Source: vra_cloud_account_gcp
 
-Provides a VMware vRA vra_cloud_account_gcp data source.
+Provides a vra_cloud_account_gcp data source.
 
 ## Example Usages
 
@@ -20,7 +20,6 @@ This is an example of how to create an GCP cloud account resource and read it as
 data "vra_cloud_account_gcp" "this" {
   id = var.vra_cloud_account_gcp_id
 }
-
 ```
 
 **GCP cloud account data source by its name:**
@@ -32,10 +31,7 @@ This is an example of how to read the cloud account data source using its name.
 data "vra_cloud_account_gcp" "this" {
   name = var.vra_cloud_account_gcp_name
 }
-
 ```
-
-
 
 ## Argument Reference
 
@@ -53,7 +49,7 @@ The following arguments are supported for an GCP cloud account data source:
 
 * `description` - A human-friendly description.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
@@ -65,9 +61,10 @@ The following arguments are supported for an GCP cloud account data source:
 
 * `regions` - A set of region names that are enabled for this account.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "vmware", "value": "provider" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_cloud_account_nsxt.html.markdown
+++ b/website/docs/d/vra_cloud_account_nsxt.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_nsxt"
+page_title: "VMware Aria Automation: vra_cloud_account_nsxt"
 description: |-
     Provides a data lookup for vra_cloud_account_nsxt.
 ---
 
-# Data Source: vra\_cloud\_account\_nsxt
+# Data Source: vra_cloud_account_nsxt
 
-Provides a VMware vRA vra_cloud_account_nsxt data source.
+Provides a vra_cloud_account_nsxt data source.
 
 ## Example Usages
 
@@ -20,7 +20,6 @@ This is an example of how to read the cloud account data source using its id.
 data "vra_cloud_account_nsxt" "this" {
   id = var.vra_cloud_account_nsxt_id
 }
-
 ```
 
 **NSX-T cloud account data source by its name:**
@@ -32,10 +31,7 @@ This is an example of how to read the cloud account data source using its name.
 data "vra_cloud_account_nsxt" "this" {
   name = var.vra_cloud_account_nsxt_name
 }
-
 ```
-
-
 
 ## Argument Reference
 
@@ -57,15 +53,16 @@ The following arguments are supported for an NSX-T cloud account data source:
 
 * `hostname` - Host name for the NSX-T cloud account.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
 * `owner` - Email of the user that owns the entity.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "vmware", "value": "provider" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_cloud_account_nsxv.html.markdown
+++ b/website/docs/d/vra_cloud_account_nsxv.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_nsxv"
+page_title: "VMware Aria Automation: vra_cloud_account_nsxv"
 description: |-
     Provides a data lookup for vra_cloud_account_nsxv.
 ---
 
-# Data Source: vra\_cloud\_account\_nsxv
+# Data Source: vra_cloud_account_nsxv
 
-Provides a VMware vRA vra_cloud_account_nsxv data source.
+Provides a vra_cloud_account_nsxv data source.
 
 ## Example Usages
 
@@ -20,7 +20,6 @@ This is an example of how to read the cloud account data source using its id.
 data "vra_cloud_account_nsxv" "this" {
   id = var.vra_cloud_account_nsxv_id
 }
-
 ```
 
 **NSX-V cloud account data source by its name:**
@@ -32,10 +31,7 @@ This is an example of how to read the cloud account data source using its name.
 data "vra_cloud_account_nsxv" "this" {
   name = var.vra_cloud_account_nsxv_name
 }
-
 ```
-
-
 
 ## Argument Reference
 
@@ -57,15 +53,16 @@ The following arguments are supported for an NSX-V cloud account data source:
 
 * `hostname` - Host name for the NSX-V cloud account.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
 * `owner` - Email of the user that owns the entity.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "vmware", "value": "provider" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_cloud_account_vmc.html.markdown
+++ b/website/docs/d/vra_cloud_account_vmc.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_vmc"
+page_title: "VMware Aria Automation: vra_cloud_account_vmc"
 description: |-
     Provides a data lookup for vra_cloud_account_vmc.
 ---
 
-# Data Source: vra\_cloud\_account\_vmc
+# Data Source: vra_cloud_account_vmc
 
-Provides a VMware vRA vra_cloud_account_vmc data source.
+Provides a vra_cloud_account_vmc data source.
 
 ## Example Usages
 
@@ -20,7 +20,6 @@ This is an example of how to read the cloud account data source using its id.
 data "vra_cloud_account_vmc" "this" {
   id = var.vra_cloud_account_vmc_id
 }
-
 ```
 
 **vmc cloud account data source by its name:**
@@ -32,10 +31,7 @@ This is an example of how to read the cloud account data source using its name.
 data "vra_cloud_account_vmc" "this" {
   name = var.vra_cloud_account_vmc_name
 }
-
 ```
-
-
 
 ## Argument Reference
 
@@ -53,7 +49,7 @@ The following arguments are supported for an vmc cloud account data source:
 
 * `description` - A human-friendly description.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `nsx_hostname` - The IP address of the NSX Manager server in the specified SDDC / FQDN.
 
@@ -65,9 +61,10 @@ The following arguments are supported for an vmc cloud account data source:
 
 * `sddc_name` - Identifier of the on-premise SDDC to be used by this cloud account. Note that NSX-V SDDCs are not supported.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "vmware", "value": "provider" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_cloud_account_vsphere.html.markdown
+++ b/website/docs/d/vra_cloud_account_vsphere.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_vsphere"
+page_title: "VMware Aria Automation: vra_cloud_account_vsphere"
 description: |-
     Provides a data lookup for vra_cloud_account_vsphere.
 ---
 
-# Data Source: vra\_cloud\_account\_vsphere
+# Data Source: vra_cloud_account_vsphere
 
-Provides a VMware vRA vra_cloud_account_vsphere data source.
+Provides a vra_cloud_account_vsphere data source.
 
 ## Example Usages
 
@@ -20,7 +20,6 @@ This is an example of how to read the cloud account data source using its id.
 data "vra_cloud_account_vsphere" "this" {
   id = var.vra_cloud_account_vsphere_id
 }
-
 ```
 
 **vSphere cloud account data source by its name:**
@@ -32,10 +31,7 @@ This is an example of how to read the cloud account data source using its name.
 data "vra_cloud_account_vsphere" "this" {
   name = var.vra_cloud_account_vsphere_name
 }
-
 ```
-
-
 
 ## Argument Reference
 
@@ -65,12 +61,12 @@ The following arguments are supported for an vSphere cloud account data source:
 
 * `owner` - Email of the user that owns the entity.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "vmware", "value": "provider" } ]`
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.
 
 * `username` - The vSphere username to authenticate the vsphere account.
-

--- a/website/docs/d/vra_content_sharing_policy.html.markdown
+++ b/website/docs/d/vra_content_sharing_policy.html.markdown
@@ -1,10 +1,10 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_content_sharing_policy"
+page_title: "VMware Aria Automation: vra_content_sharing_policy"
 description: A data source for content sharing policy.
 ---
 
-# Data Source: vra\_content\_sharing\_policy
+# Data Source: vra_content_sharing_policy
 
 This is an example of how to lookup a content sharing policy data source:
 

--- a/website/docs/d/vra_data_collector.html.markdown
+++ b/website/docs/d/vra_data_collector.html.markdown
@@ -1,30 +1,34 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_data_collector"
+page_title: "VMware Aria Automation: vra_data_collector"
 description: |-
   Provides a data lookup for data collector data source.
 ---
 
 # Data Source: vra_data_collector
+
 ## Example Usages
 
 This is an example of how to lookup a data collector.
 
 **Data collector data source by its name:**
+
 ```hcl
 data "vra_data_collector" "this" {
   name = var.data_collector_name
 }
 ```
+
 The data collector data source supports the following arguments:
 
 ## Argument Reference
+
 * `name` - (Required) Data collector name. Example: `Datacollector1`
 
 ## Attribute Reference
-* `hostname` - Data collector host name. Example: `dc1-lnd.mycompany.com`
+
+* `hostname` - Data collector host name. Example: `dc1-lnd.example.com`
 
 * `ip_address` - IPv4 Address of the data collector VM. Example: `10.0.0.1`
 
 * `status` - Current status of the data collector. Example: `ACTIVE`, `INACTIVE`
-

--- a/website/docs/d/vra_deployment.html.markdown
+++ b/website/docs/d/vra_deployment.html.markdown
@@ -1,16 +1,16 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Data source vra_deployment"
+page_title: "VMware Aria Automation: Data source vra_deployment"
 description: A deployment data source.
 ---
 
-# Data Source: vra\_deployment
+# Data Source: vra_deployment
 
-This data source provides information about a deployment in vRA.
+This data source provides information about a deployment.
 
 ## Example Usages
 
-This is an example of how to get a vRA deployment by its name.
+This is an example of how to get deployment by its name.
 
 ```hcl
 data "vra_deployment" "this" {
@@ -18,14 +18,13 @@ data "vra_deployment" "this" {
 }
 ```
 
-This is an example of how to get a vRA cloud template by its id.
+This is an example of how to get a cloud template by its id.
 
 ```hcl
 data "vra_deployment" "this" {
   id = var.deployment_id
 }
 ```
-
 
 ## Argument Reference
 
@@ -38,7 +37,6 @@ data "vra_deployment" "this" {
 * `id` - (Optional) The id of the deployment. One of `id` or `name` must be provided.
 
 * `name` - (Optional) The name of the deployment. One of `id` or `name` must be provided.
-
 
 ## Attribute Reference
 
@@ -56,70 +54,70 @@ data "vra_deployment" "this" {
 
 * `description` - A human-friendly description.
 
-* `expense` - Expense incurred for the deployment. 
+* `expense` - Expense incurred for the deployment.
 
-    * `additional_expense` - Additional expense incurred for the resource.
-    
-    * `code` - Expense sync message code if any.
-    
-    * `compute_expense` - Compute expense of the entity.
-    
-    * `last_update_time` - Last expense sync time.
-    
-    * `message` - Expense sync message if any.
-    
-    * `network_expense` - Network expense of the entity.
-    
-    * `storage_expense` - Storage expense of the entity.
-    
-    * `total_expense` - Total expense of the entity.
-    
-    * `unit` - Monetary unit.
+  * `additional_expense` - Additional expense incurred for the resource.
+
+  * `code` - Expense sync message code if any.
+
+  * `compute_expense` - Compute expense of the entity.
+
+  * `last_update_time` - Last expense sync time.
+
+  * `message` - Expense sync message if any.
+
+  * `network_expense` - Network expense of the entity.
+
+  * `storage_expense` - Storage expense of the entity.
+
+  * `total_expense` - Total expense of the entity.
+
+  * `unit` - Monetary unit.
 
 * `inputs` - Inputs provided by the user while requesting / updating the deployment.
 
 * `last_request` - Represents deployment requests.
 
-    * `action_id` - Identifier of the requested action.
-    
-    * `approved_at` - Time at which the request was approved.
-    
-    * `blueprint_id` - Identifier of the requested blueprint in the form ‘UUID:version’.
-    
-    * `cancelable` - Indicates whether request can be canceled or not. 
-    
-    * `catalog_item_id` - Identifier of the requested catalog item in the form ‘UUID:version’.
-    
-    * `completed_at` - Time at which the request completed.
-    
-    * `completed_tasks` - The number of tasks completed while fulfilling this request.
-    
-    * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
-    
-    * `details` - Longer user-friendly details of the request.
- 
-    * `dismissed` - Indicates whether request is in dismissed state.
-     
-    * `id` - Request identifier.
- 
-    * `initialized_at` - Time at which the request was initialized.
+  * `action_id` - Identifier of the requested action.
 
-    * `inputs` - List of request inputs.
-    
-    * `name` - Short user-friendly label of the request (e.g. ‘shuting down myVM’).
-    
-    * `outputs` - Request outputs.
-    
-    * `requested_by` - The user that initiated the request.
-     
-    * `resource_name` - Optional resource name to which the request applies to.
- 
-    * `status` - Request overall execution status. Supported values: `CREATED`, `PENDING`, `INITIALIZATION`, `CHECKING_APPROVAL`, `APPROVAL_PENDING`, `INPROGRESS`, `COMPLETION`, `APPROVAL_REJECTED`, `ABORTED`, `SUCCESSFUL`, `FAILED`.
+  * `approved_at` - Time at which the request was approved.
 
-    * `total_tasks` -The total number of tasks need to be completed to fulfil this request.
+  * `blueprint_id` - Identifier of the requested blueprint in the form ‘UUID:version’.
 
-    * `updated_at` - Last update time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
-    
+  * `cancelable` - Indicates whether request can be canceled or not.
+
+  * `catalog_item_id` - Identifier of the requested catalog item in the form ‘UUID:version’.
+
+  * `completed_at` - Time at which the request completed.
+
+  * `completed_tasks` - The number of tasks completed while fulfilling this request.
+
+  * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
+
+  * `details` - Longer user-friendly details of the request.
+
+  * `dismissed` - Indicates whether request is in dismissed state.
+
+  * `id` - Request identifier.
+
+  * `initialized_at` - Time at which the request was initialized.
+
+  * `inputs` - List of request inputs.
+
+  * `name` - Short user-friendly label of the request (e.g. ‘shuting down myVM’).
+
+  * `outputs` - Request outputs.
+
+  * `requested_by` - The user that initiated the request.
+
+  * `resource_name` - Optional resource name to which the request applies to.
+
+  * `status` - Request overall execution status. Supported values: `CREATED`, `PENDING`, `INITIALIZATION`, `CHECKING_APPROVAL`, `APPROVAL_PENDING`, `INPROGRESS`, `COMPLETION`, `APPROVAL_REJECTED`, `ABORTED`, `SUCCESSFUL`, `FAILED`.
+
+  * `total_tasks` -The total number of tasks need to be completed to fulfil this request.
+
+  * `updated_at` - Last update time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
+
 * `last_updated_at` - Date when the entity was last updated. The date is in ISO 6801 and UTC.
 
 * `last_updated_by` - The user that last updated the deployment.
@@ -132,54 +130,54 @@ data "vra_deployment" "this" {
 
 * `project` - The project this entity belongs to.
 
-    * `description` - A human friendly description.
-    
-    * `id` - Id of the entity.
-    
-    * `name` - Name of the entity.
-    
-    * `version` - Version of the entity, if applicable.
+  * `description` - A human friendly description.
+
+  * `id` - Id of the entity.
+
+  * `name` - Name of the entity.
+
+  * `version` - Version of the entity, if applicable.
 
 * `project_id` - The id of the project this deployment belongs to.
 
 * `resources` - Expanded resources for the deployment. Content of this property will not be maintained backward compatible.
 
-    * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
-    
-    * `depends_on` - A list of other resources this resource depends on.
-    
-    * `description` - A description of the resource.
-    
-    * `expense` - Expense incurred for this resource. 
-    
-        * `additional_expense` - Additional expense incurred for the resource.
-        
-        * `code` - Expense sync message code if any.
-        
-        * `compute_expense` - Compute expense of the entity.
-        
-        * `last_update_time` - Last expense sync time.
-        
-        * `message` - Expense sync message if any.
-        
-        * `network_expense` - Network expense of the entity.
-        
-        * `storage_expense` - Storage expense of the entity.
-        
-        * `total_expense` - Total expense of the entity.
-        
-        * `unit` - Monetary unit.
-    
-    * `id` - Unique identifier of the resource.
-    
-    * `name` - Name of the resource.
-    
-    * `properties_json` - List of properties in the encoded JSON string format. 
-    
-    * `state` - The current state of the resource. Supported values are `PARTIAL`, `TAINTED`, `OK.`
-    
-    * `sync_status` - The current sync status. Supported values are `SUCCESS`, `MISSING`, `STALE`.
-    
-    * `type` - Type of the resource.
+  * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
+
+  * `depends_on` - A list of other resources this resource depends on.
+
+  * `description` - A description of the resource.
+
+  * `expense` - Expense incurred for this resource.
+
+    * `additional_expense` - Additional expense incurred for the resource.
+
+    * `code` - Expense sync message code if any.
+
+    * `compute_expense` - Compute expense of the entity.
+
+    * `last_update_time` - Last expense sync time.
+
+    * `message` - Expense sync message if any.
+
+    * `network_expense` - Network expense of the entity.
+
+    * `storage_expense` - Storage expense of the entity.
+
+    * `total_expense` - Total expense of the entity.
+
+    * `unit` - Monetary unit.
+
+  * `id` - Unique identifier of the resource.
+
+  * `name` - Name of the resource.
+
+  * `properties_json` - List of properties in the encoded JSON string format.
+
+  * `state` - The current state of the resource. Supported values are `PARTIAL`, `TAINTED`, `OK.`
+
+  * `sync_status` - The current sync status. Supported values are `SUCCESS`, `MISSING`, `STALE`.
+
+  * `type` - Type of the resource.
 
 * `status` - The status of the deployment with respect to its life cycle operations.

--- a/website/docs/d/vra_fabric_compute.html.markdown
+++ b/website/docs/d/vra_fabric_compute.html.markdown
@@ -1,8 +1,8 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_compute"
+page_title: "VMware Aria Automation: vra_fabric_compute"
 description: |-
-  Provides a data lookup for vRA fabric computes.
+  Provides a data lookup for VMware Aria Automation fabric computes.
 ---
 
 # Data Source: vra_fabric_compute
@@ -33,9 +33,9 @@ A fabric compute data source supports the following arguments:
 
 ## Argument Reference
 
-* `id` - (Optional) The id of the fabric compute resource instance. Only one of 'id' or 'filter' must be specified.
+* `id` - (Optional) The id of the fabric compute resource instance. Only one of `id` or `filter` must be specified.
 
-* `filter` - (Optional) Search criteria to narrow down the fabric compute resource instance. Only one of 'id' or 'filter' must be specified.
+* `filter` - (Optional) Search criteria to narrow down the fabric compute resource instance. Only one of `id` or `filter` must be specified.
 
 ## Attribute Reference
 
@@ -53,7 +53,7 @@ A fabric compute data source supports the following arguments:
 
 * `lifecycle_state` - Lifecycle status of the compute instance.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier for the fabric compute resource instance.
 
@@ -64,7 +64,9 @@ A fabric compute data source supports the following arguments:
 * `power_state` - Power state of fabric compute instance.
 
 * `tags` -  A set of tag keys and optional values that were set on this resource:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `type` - Type of the fabric compute instance.

--- a/website/docs/d/vra_fabric_datastore_vsphere.html.markdown
+++ b/website/docs/d/vra_fabric_datastore_vsphere.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_datastore_vsphere"
+page_title: "VMware Aria Automation: vra_fabric_datastore_vsphere"
 description: |-
   Provides a data lookup for vSphere fabric datastores.
 ---
@@ -8,6 +8,7 @@ description: |-
 # Data Source: vra_fabric_datastore_vsphere
 
 ## Example Usages
+
 This is an example of how to lookup vSphere fabric datastores.
 
 **vSphere fabric datastore data source by Id:**
@@ -32,9 +33,9 @@ A vSphere fabric datastore data source supports the following arguments:
 
 ## Argument Reference
 
-* `id` - (Optional) The id of the vSphere fabric datastore resource instance. Only one of 'id' or 'filter' must be specified.
+* `id` - (Optional) The id of the vSphere fabric datastore resource instance. Only one of `id` or `filter` must be specified.
 
-* `filter` - (Optional) Search criteria to narrow down the vSphere fabric datastore resource instance. Only one of 'id' or 'filter' must be specified.
+* `filter` - (Optional) Search criteria to narrow down the vSphere fabric datastore resource instance. Only one of `id` or `filter` must be specified.
 
 ## Attribute Reference
 
@@ -50,7 +51,7 @@ A vSphere fabric datastore data source supports the following arguments:
 
 * `free_size_gb` - Indicates free size available in datastore.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier for the vSphere fabric datastore resource instance.
 
@@ -59,7 +60,9 @@ A vSphere fabric datastore data source supports the following arguments:
 * `owner` - Email of the user that owns the entity.
 
 * `tags` -  A set of tag keys and optional values that were set on this resource:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `type` - Type of datastore.

--- a/website/docs/d/vra_fabric_network.html.markdown
+++ b/website/docs/d/vra_fabric_network.html.markdown
@@ -1,23 +1,25 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_network"
+page_title: "VMware Aria Automation: vra_fabric_network"
 description: |-
-  Provides a data lookup for vRA fabric networks.
+  Provides a data lookup for VMware Aria Automation fabric networks.
 ---
 
 # Data Source: vra_fabric_network
+
 ## Example Usages
+
 This is an example of how to lookup fabric networks.
 
 **Fabric network by filter query:**
 
 ```hcl
-# Lookup vRA fabric network using its name
+# Lookup VMware Aria Automation fabric network using its name
 data "vra_fabric_network" "this" {
   filter = "name eq '${var.name}'"
 }
 
-# Lookup vRA fabric network using its name and regionId
+# Lookup VMware Aria Automation fabric network using its name and regionId
 data "vra_fabric_network" "this" {
   filter = "name eq '${var.name}' and externalRegionId eq '${var.external_region_id}'"
 }
@@ -26,16 +28,18 @@ data "vra_fabric_network" "this" {
 A fabric network data source supports the following arguments:
 
 ## Argument Reference
-* `filter` - (Required) Filter query string that is supported by vRA multi-cloud IaaS API.
+
+* `filter` - (Required) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API.
 
 ## Attribute Reference
+
 * `cloud_account_ids` - Set of ids of the cloud accounts this entity belongs to.
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
 
 * `cidr` - Network CIDR to be used.
 
-* `id` - ID of the vRA fabric network.
+* `id` - ID of the VMware Aria Automation fabric network.
 
 * `is_public` - Indicates whether the sub-network supports public IP assignment.
 
@@ -47,7 +51,7 @@ A fabric network data source supports the following arguments:
 
 * `external_region_id` - The id of the region for which this network is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - Name of the fabric network.
 

--- a/website/docs/d/vra_fabric_storage_account_azure.html.markdown
+++ b/website/docs/d/vra_fabric_storage_account_azure.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_storage_account_azure"
+page_title: "VMware Aria Automation: vra_fabric_storage_account_azure"
 description: |-
   Provides a data lookup for fabric Azure storage account.
 ---
 
 # Data Source: vra_fabric_storage_account_azure
+
 ## Example Usages
+
 This is an example of how to lookup fabric Azure storage account.
 
 **Fabric Azure storage account by Id:**
@@ -30,11 +32,13 @@ data "vra_fabric_storage_account_azure" "this" {
 A fabric Azure storage account supports the following arguments:
 
 ## Argument Reference
-* `filter` - Search criteria to narrow down the fabric Azure storage accounts. Only one of 'filter' or 'id' must be specified.
 
-* `id` - The id of the fabric Azure storage account. Only one of 'filter' or 'id' must be specified.
+* `filter` - Search criteria to narrow down the fabric Azure storage accounts. Only one of `filter` or `id` must be specified.
+
+* `id` - The id of the fabric Azure storage account. Only one of `filter` or `id` must be specified.
 
 ## Attribute Reference
+
 * `cloud_account_ids` - Set of ids of the cloud accounts this entity belongs to.
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
@@ -45,7 +49,7 @@ A fabric Azure storage account supports the following arguments:
 
 * `external_region_id` - The id of the region for which this entity is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -53,8 +57,7 @@ A fabric Azure storage account supports the following arguments:
 
 * `owner` - Email of the user that owns the entity.
 
-* `tags` -  A set of tag keys and optional values that were set on this resource.
-                       example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` -  A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `type` -  Indicates the performance tier for the storage type. Premium disks are SSD backed and Standard disks are HDD backed. example: `Standard_LRS / Premium_LRS`
 

--- a/website/docs/d/vra_fabric_storage_policy_vsphere.html.markdown
+++ b/website/docs/d/vra_fabric_storage_policy_vsphere.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_storage_policy_vsphere"
+page_title: "VMware Aria Automation: vra_fabric_storage_policy_vsphere"
 description: |-
   Provides a data lookup for fabric vSphere storage policy.
 ---
 
 # Data Source: vra_fabric_storage_policy_vsphere
+
 ## Example Usages
+
 This is an example of how to lookup fabric vSphere storage policies.
 
 **Fabric vSphere storage policy by Id:**
@@ -30,11 +32,13 @@ data "vra_fabric_storage_policy_vsphere" "this" {
 A fabric vSphere storage policy supports the following arguments:
 
 ## Argument Reference
-* `filter` - Search criteria to narrow down the fabric vSphere storage policy. Only one of 'filter' or 'id' must be specified.
 
-* `id` - The id of the fabric vSphere storage policy. Only one of 'filter' or 'id' must be specified.
+* `filter` - Search criteria to narrow down the fabric vSphere storage policy. Only one of `filter` or `id` must be specified.
+
+* `id` - The id of the fabric vSphere storage policy. Only one of `filter` or `id` must be specified.
 
 ## Attribute Reference
+
 * `cloud_account_ids` - Set of ids of the cloud accounts this entity belongs to.
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
@@ -45,9 +49,9 @@ A fabric vSphere storage policy supports the following arguments:
 
 * `external_region_id` - The id of the region for which this entity is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
-* `name` - A human-friendly name used as an identifier in APIs that support this option.  Only one of 'filter', 'id', 'name' or 'region_id' must be specified.
+* `name` - A human-friendly name used as an identifier in APIs that support this option.  Only one of `filter`, `id`, `name`, or `region_id` must be specified.
 
 * `org_id` - The id of the organization this entity belongs to.
 

--- a/website/docs/d/vra_image.html.markdown
+++ b/website/docs/d/vra_image.html.markdown
@@ -1,11 +1,11 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_image"
+page_title: "VMware Aria Automation: vra_image"
 description: |-
-  Provides a data source for vRealize Automation images.
+  Provides a data source for VMware Aria Automation images.
 ---
 
-# Data Source: vra\_image
+# Data Source: vra_image
 
 The `vra_image` data source can be used to discover the lookup machine images with cloud accounts. This can then be used with resource that require an image. For example, to create an image profile using the `vra_image_profile` resource.
 
@@ -33,8 +33,8 @@ data "vra_image" "this" {
 
 ## Argument Reference
 
-* `id` - (Optional) The id of the image resource instance. Only one of 'id' or 'filter' must be specified.
-* `filter` - (Optional) Search criteria to narrow down the image resource instance. Only one of 'id' or 'filter' must be specified.
+* `id` - (Optional) The id of the image resource instance. Only one of `id` or `filter` must be specified.
+* `filter` - (Optional) Search criteria to narrow down the image resource instance. Only one of `id` or `filter` must be specified.
 
 ## Attribute Reference
 
@@ -42,8 +42,8 @@ data "vra_image" "this" {
 * `custom_properties` - A list of key value pair of custom properties for the image resource.
 * `description` - A human-friendly description.
 * `external_id` - External entity Id on the provider side.
-* `links` - HATEOAS of the entity.
-* `name` - A human-friendly name used as an identifier for the image resource instance. 
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
+* `name` - A human-friendly name used as an identifier for the image resource instance.
 * `org_id` - The id of the organization this entity belongs to.
 * `os_family` - Operating System family of the image.
 * `owner` - Email of the user that owns the entity.

--- a/website/docs/d/vra_image_profile.html.markdown
+++ b/website/docs/d/vra_image_profile.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_image_profile"
+page_title: "VMware Aria Automation: vra_image_profile"
 description: |-
   Provides a data lookup for vra_image_profile.
 ---
 
 # Data Source: vra_image_profile
+
 ## Example Usages
+
 This is an example of how to read an image profile as data source.
 
 **Image profile data source by its id:**
@@ -17,7 +19,7 @@ data "vra_image_profile" "this" {
 }
 ```
 
-**Vra image profile data source filter by region id:**
+**image profile data source filter by region id:**
 
 ```hcl
 data "vra_image_profile" "this" {
@@ -29,13 +31,13 @@ An image profile data source supports the following arguments:
 
 ## Argument Reference
 
-* `filter` - (Optional) Filter query string that is supported by vRA multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
+* `filter` - (Optional) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
 
 * `id` - (Optional) The id of the image profile instance.
 
 * `name` - (Optional) A human-friendly name used as an identifier in APIs that support this option.
 
-* `region_id` - (Optional) The id of the region for which this profile is defined as in vRealize Automation(vRA).
+* `region_id` - (Optional) The id of the region for which this profile is defined as in VMware Aria Automation.
 
 ## Attributes Reference
 

--- a/website/docs/d/vra_machine.html.markdown
+++ b/website/docs/d/vra_machine.html.markdown
@@ -1,34 +1,35 @@
----layout: "vra"
-page_title: "VMware vRealize Automation: vra_machine"
+---
+layout: "vra"
+page_title: "VMware Aria Automation: vra_machine"
 description: |-
   Provides a data lookup for vra_machine.
 ---
 
 # Data Source: vra_machine
+
 ## Example Usages
 
 This is an example of how to read a machine data source.
 
 ```hcl
-
 data "vra_machine" "this" {
   id = var.my_machine_id
 }
-
 ```
 
 **Machine data source filter by name:**
-```hcl
 
+```hcl
 data "vra_machine" "this" {
   filter = "name eq '${var.machine_name}'"
 }
-
 ```
+
 ## Argument Reference
+
 * `description` - (Optional) A human-friendly description.
 
-* `filter` - (Optional) Filter query string that is supported by vRA multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
+* `filter` - (Optional) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
 
 * `id` - (Optional) The id of the image profile instance.
 
@@ -50,7 +51,7 @@ data "vra_machine" "this" {
 
 * `external_zone_id` - The external zoneId of the resource.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -62,7 +63,6 @@ data "vra_machine" "this" {
 
 * `project_id` - The id of the project this resource belongs to.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `update_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_network.html.markdown
+++ b/website/docs/d/vra_network.html.markdown
@@ -1,10 +1,12 @@
----layout: "vra"
-page_title: "VMware vRealize Automation: vra_network"
+---
+layout: "vra"
+page_title: "VMware Aria Automation: vra_network"
 description: |-
   Provides a data lookup for vra_network.
 ---
 
 # Data Source: vra_network
+
 ## Example Usages
 
 This is an example of how to read a network data source.
@@ -35,11 +37,11 @@ data "vra_network" "test-network" {
 
 ## Argument Reference
 
-* `id` - (Optional) The id of the network instance. Only one of 'id', 'name' or 'filter' must be specified.
+* `id` - (Optional) The id of the network instance. Only one of `id`, `name`, or `filter` must be specified.
 
-* `name` - (Optional) The human-friendly name of the network instance. Only one of 'id', 'name' or 'filter' must be specified.
+* `name` - (Optional) The human-friendly name of the network instance. Only one of `id`, `name`, or `filter` must be specified.
 
-* `filter` - (Optional) The search criteria to narrow down the network instance. Only one of 'id', 'name' or 'filter' must be specified.
+* `filter` - (Optional) The search criteria to narrow down the network instance. Only one of `id`, `name`, or `filter` must be specified.
 
 ## Attribute Reference
 
@@ -59,7 +61,7 @@ data "vra_network" "test-network" {
 
 * `external_zone_id` - The external zoneId of the resource.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `organization_id` - The id of the organization this entity belongs to.
 
@@ -67,7 +69,6 @@ data "vra_network" "test-network" {
 
 * `project_id` - The id of the project this resource belongs to.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `update_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_network_domain.html.markdown
+++ b/website/docs/d/vra_network_domain.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_network_domain"
+page_title: "VMware Aria Automation: vra_network_domain"
 description: |-
   Provides a data lookup for Network domain objects.
 ---
 
 # Data Source: vra_network_domain
+
 ## Example Usages
+
 This is an example of how to lookup Network domain objects.
 
 **Network Domain by filter query:**
@@ -21,9 +23,11 @@ data "vra_network_domain" "this" {
 A network domain object supports the following arguments:
 
 ## Argument Reference
+
 * `filter` - (Required) Search criteria to narrow down the network domain objects.
 
 ## Attribute Reference
+
 * `cloud_account_ids` - Set of ids of the cloud accounts this entity belongs to.
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
@@ -36,7 +40,7 @@ A network domain object supports the following arguments:
 
 * `id` - ID of the fabric network domain object.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - Name of the network domain.
 

--- a/website/docs/d/vra_network_profile.html.markdown
+++ b/website/docs/d/vra_network_profile.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_network_profile"
+page_title: "VMware Aria Automation: vra_network_profile"
 description: |-
   Provides a data lookup for vra_network_profile.
 ---
 
 # Data Source: vra_network_profile
+
 ## Example Usages
+
 This is an example of how to create a network profile resource.
 
 **Network profile data source by its id:**
@@ -17,7 +19,7 @@ data "vra_network_profile" "this" {
 }
 ```
 
-**Vra network profile data source filter by region id:**
+**network profile data source filter by region id:**
 
 ```hcl
 data "vra_network_profile" "this" {
@@ -29,7 +31,7 @@ A network profile data source supports the following arguments:
 
 ## Argument Reference
 
-* `filter` - (Optional) Filter query string that is supported by vRA multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
+* `filter` - (Optional) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
 
 * `id` - (Optional) The id of the image profile instance.
 
@@ -46,14 +48,14 @@ A network profile data source supports the following arguments:
 * `external_region_id` - The external regionId of the resource.
 
 * `fabric_network_ids` - A list of fabric network Ids which are assigned to the network profile.
-                         example: `[ "6543" ]`
+                         Example: `[ "6543" ]`
 * `isolated_network_cidr_prefix` - The CIDR prefix length to be used for the isolated networks that are created with the network profile.
 
 * `isolated_network_domain_cidr` - CIDR of the isolation network domain.
 
 * `isolation_type` - Specifies the isolation type e.g. none, subnet or security group
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -61,12 +63,11 @@ A network profile data source supports the following arguments:
 
 * `owner` - Email of the user that owns the entity.
 
-* `region_id` - The id of the region for which this profile is defined as in vRealize Automation(vRA).
+* `region_id` - The id of the region for which this profile is defined as in VMware Aria Automation.
 
 * `security_group_ids` - A list of security group Ids which are assigned to the network profile.
-                         example: `[ "6545" ]`
+                         Example: `[ "6545" ]`
 
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_project.html.markdown
+++ b/website/docs/d/vra_project.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_project"
+page_title: "VMware Aria Automation: vra_project"
 description: |-
   Provides a data lookup for vra_project.
 ---
@@ -8,6 +8,7 @@ description: |-
 # Data Source: vra_project
 
 ## Example Usages
+
 This is an example of how to create a project data source.
 
 **Project data source by its id:**
@@ -30,11 +31,11 @@ A project data source supports the following arguments:
 
 ## Argument Reference
 
-* `administrators` - (Optional) A list of administrator users associated with the project. Only administrators can manage project's configuration. 
+* `administrators` - (Optional) A list of administrator users associated with the project. Only administrators can manage project's configuration.
 
   > **Note**:  Deprecated - please use `administrator_roles` instead.
 
-* `administrator_roles` - (Optional) Administrator users or groups associated with the project. Only administrators can manage project's configuration. 
+* `administrator_roles` - (Optional) Administrator users or groups associated with the project. Only administrators can manage project's configuration.
 
 * `constraints` - (Optional) A list of storage, network and extensibility constraints to be applied when provisioning through this project.
 
@@ -46,11 +47,11 @@ A project data source supports the following arguments:
 
 * `machine_naming_template` - (Optional) The naming template to be used for resources provisioned in this project.
 
-* `members` - (Optional) A list of member users associated with the project. 
-  
+* `members` - (Optional) A list of member users associated with the project.
+
   > **Note**:  Deprecated - please use `member_roles` instead.
 
-* `member_roles` - (Optional) Member users or groups associated with the project. 
+* `member_roles` - (Optional) Member users or groups associated with the project.
 
 * `name` - (Optional) A human-friendly name used as an identifier in APIs that support this option.
 
@@ -66,8 +67,8 @@ A project data source supports the following arguments:
 
 * `supervisor_roles` - (Optional) Supervisor users or groups associated with the project.d
 
-* `viewers` - (Optional) A list of viewer users associated with the project. 
+* `viewers` - (Optional) A list of viewer users associated with the project.
 
   > **Note**:  Deprecated - please use `viewer_roles` instead.
 
-* `viewer_roles` - (Optional) Viewer users or groups associated with the project. 
+* `viewer_roles` - (Optional) Viewer users or groups associated with the project.

--- a/website/docs/d/vra_region.html.markdown
+++ b/website/docs/d/vra_region.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_region"
+page_title: "VMware Aria Automation: vra_region"
 sidebar_current: "docs-vra-datasource-vra-region"
 description: |-
   Provides a data lookup for vra_region.
 ---
 
-# Data Source: vra\_region
+# Data Source: vra_region
 
 This is an example of how to lookup a region data source:
 
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `region` - (Optional) The specific region associated with the cloud account. On vSphere, this is the external ID.
 
--> **Note:** One of `id`, `filter` or` cloud_account_id` and `region` must be specified.
+-> **Note:** One of `id`, `filter` or`cloud_account_id` and `region` must be specified.
 
 ## Attribute Reference
 

--- a/website/docs/d/vra_region_enumeration.html.markdown
+++ b/website/docs/d/vra_region_enumeration.html.markdown
@@ -1,18 +1,20 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_region_enumeration"
+page_title: "VMware Aria Automation: vra_region_enumeration"
 description: |-
   Provides a data lookup for region enumeration data source.
 ---
 
 # Data Source: vra_region_enumeration
+
 ## Example Usages
 
 This is an example of how to lookup a region enumeration data source.
 
 DeprecationMessage: 'region_enumeration' is deprecated. Use 'region_enumeration_vsphere' instead.
 
-**Region enumeration data source for vSphere**
+Region enumeration data source for vSphere:
+
 ```hcl
 data "vra_region_enumeration_vsphere" "this" {
   accept_self_signed_cert = false
@@ -28,16 +30,17 @@ data "vra_region_enumeration_vsphere" "this" {
 The region enumeration data source supports the following arguments:
 
 ## Argument Reference
+
 * `accept_self_signed_cert` - (Optional) Accept self signed certificate when connecting to vSphere. Example: `false`
 
 * `dc_id` - (Optional) ID of a data collector vm deployed in the on premise infrastructure. Example: `d5316b00-f3b8-4895-9e9a-c4b98649c2ca`
 
-* `hostname` - (Required) Host name for the cloud account endpoint. Example: `dc1-lnd.mycompany.com`
+* `hostname` - (Required) Host name for the cloud account endpoint. Example: `dc1-lnd.example.com`
 
 * `password` - (Required) Password for the user used to authenticate with the cloud Account
 
 * `username` - (Required) Username to authenticate with the cloud account
 
 ## Attribute Reference
-* `regions` - A set of datacenter managed object reference identifiers to enable provisioning on. Example: Datacenter:datacenter-2
 
+* `regions` - A set of datacenter managed object reference identifiers to enable provisioning on. Example: Datacenter:datacenter-2

--- a/website/docs/d/vra_region_enumeration_aws.html.markdown
+++ b/website/docs/d/vra_region_enumeration_aws.html.markdown
@@ -1,16 +1,18 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_region_enumeration_aws"
+page_title: "VMware Aria Automation: vra_region_enumeration_aws"
 description: |-
   Provides a data lookup for region enumeration for AWS cloud account.
 ---
 
 # Data Source: vra_region_enumeration_aws
+
 ## Example Usages
 
 This is an example of how to lookup a region enumeration data source for AWS cloud account.
 
 **Region enumeration data source for AWS, by the AWS account access key and secret key:**
+
 ```hcl
 data "vra_region_enumeration_aws" "this" {
   access_key = var.access_key
@@ -21,10 +23,11 @@ data "vra_region_enumeration_aws" "this" {
 The region enumeration data source for AWS cloud account supports the following arguments:
 
 ## Argument Reference
+
 * `access_key` - (Optional) Aws Access key ID.
 
 * `secret_key` - (Required) Aws Secret Access Key.
 
 ## Attribute Reference
-* `regions` - A set of Region names to enable provisioning on. Example: `["us-east-2", "ap-northeast-1"]`
 
+* `regions` - A set of Region names to enable provisioning on. Example: `["us-east-2", "ap-northeast-1"]`

--- a/website/docs/d/vra_region_enumeration_azure.html.markdown
+++ b/website/docs/d/vra_region_enumeration_azure.html.markdown
@@ -1,16 +1,18 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_region_enumeration_azure"
+page_title: "VMware Aria Automation: vra_region_enumeration_azure"
 description: |-
   Provides a data lookup for region enumeration for Azure cloud account.
 ---
 
 # Data Source: vra_region_enumeration_azure
+
 ## Example Usages
 
 This is an example of how to lookup a region enumeration data source for Azure cloud account.
 
-**Region enumeration data source for Azure**
+Region enumeration data source for Azure:
+
 ```hcl
 data "vra_region_enumeration_azure" "this" {
   application_id  = var.application_id
@@ -23,6 +25,7 @@ data "vra_region_enumeration_azure" "this" {
 The region enumeration data source for Azure cloud account supports the following arguments:
 
 ## Argument Reference
+
 * `application_id` - (Required) Azure Client Application ID
 
 * `application_key` - (Required) Azure Client Application Secret Key
@@ -32,4 +35,5 @@ The region enumeration data source for Azure cloud account supports the followin
 * `tenant_id` - (Required) Azure Tenant ID
 
 ## Attribute Reference
+
 * `regions` - A set of Region names to enable provisioning on. Example: `["northamerica-northeast1"]`

--- a/website/docs/d/vra_region_enumeration_gcp.html.markdown
+++ b/website/docs/d/vra_region_enumeration_gcp.html.markdown
@@ -1,16 +1,18 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_region_enumeration_gcp"
+page_title: "VMware Aria Automation: vra_region_enumeration_gcp"
 description: |-
   Provides a data lookup for region enumeration for GCP cloud account.
 ---
 
 # Data Source: vra_region_enumeration_gcp
+
 ## Example Usages
 
 This is an example of how to lookup a region enumeration data source for GCP cloud account.
 
-**Region enumeration data source for GCP**
+Region enumeration data source for GCP:
+
 ```hcl
 data "vra_region_enumeration_gcp" "this" {
   client_email   = var.client_email
@@ -23,6 +25,7 @@ data "vra_region_enumeration_gcp" "this" {
 The region enumeration data source for GCP cloud account supports the following arguments:
 
 ## Argument Reference
+
 * `client_email` - (Required) Client E-mail ID.
 
 * `private_key` - (Required) GCP Private key.
@@ -32,5 +35,5 @@ The region enumeration data source for GCP cloud account supports the following 
 * `project_id` - (Required) GCP Project ID.
 
 ## Attribute Reference
-* `regions` - A set of Region names to enable provisioning on. Example: `["northamerica-northeast1"]`
 
+* `regions` - A set of Region names to enable provisioning on. Example: `["northamerica-northeast1"]`

--- a/website/docs/d/vra_region_enumeration_vmc.html.markdown
+++ b/website/docs/d/vra_region_enumeration_vmc.html.markdown
@@ -1,16 +1,18 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_region_enumeration_vmc"
+page_title: "VMware Aria Automation: vra_region_enumeration_vmc"
 description: |-
   Provides a data lookup for region enumeration for VMC cloud account.
 ---
 
 # Data Source: vra_region_enumeration_vmc
+
 ## Example Usages
 
 This is an example of how to lookup a region enumeration data source for VMC cloud account.
 
-**Region enumeration data source for VMC**
+Region enumeration data source for VMware Cloud on AWS:
+
 ```hcl
 data "vra_region_enumeration_vmc" "this" {
   accept_self_signed_cert = true
@@ -30,6 +32,7 @@ data "vra_region_enumeration_vmc" "this" {
 The region enumeration data source for VMC cloud account supports the following arguments:
 
 ## Argument Reference
+
 * `accept_self_signed_cert` - (Optional) Accept self signed certificate when connecting to vSphere. Example: `false`
 
 * `api_token` - (Required) API Token for the cloud account endpoint.
@@ -47,4 +50,5 @@ The region enumeration data source for VMC cloud account supports the following 
 * `vcenter_username` - (Required) vCenter user name for the specified SDDC.The specified user requires CloudAdmin credentials. The user does not require CloudGlobalAdmin credentials.
 
 ## Attribute Reference
+
 * `regions` - A set of Region names to enable provisioning on. Example: `["northamerica-northeast1"]`

--- a/website/docs/d/vra_region_enumeration_vsphere.html.markdown
+++ b/website/docs/d/vra_region_enumeration_vsphere.html.markdown
@@ -1,16 +1,18 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_region_enumeration_vsphere"
+page_title: "VMware Aria Automation: vra_region_enumeration_vsphere"
 description: |-
   Provides a data lookup for region enumeration for vSphere cloud account.
 ---
 
 # Data Source: vra_region_enumeration_vsphere
+
 ## Example Usages
 
 This is an example of how to lookup a region enumeration data source for vSphere cloud account.
 
-**Region enumeration data source for vSphere**
+Region enumeration data source for vSphere:
+
 ```hcl
 data "vra_region_enumeration_vsphere" "this" {
   accept_self_signed_cert = false
@@ -26,15 +28,17 @@ data "vra_region_enumeration_vsphere" "this" {
 The region enumeration data source for vSphere cloud account supports the following arguments:
 
 ## Argument Reference
+
 * `accept_self_signed_cert` - (Optional) Accept self signed certificate when connecting to vSphere. Example: `false`
 
 * `dc_id` - (Required) ID of a data collector vm deployed in the on premise infrastructure. Example: `d5316b00-f3b8-4895-9e9a-c4b98649c2ca`
 
-* `hostname` - (Required) Host name for the cloud account endpoint. Example: dc1-lnd.mycompany.com
+* `hostname` - (Required) Host name for the cloud account endpoint. Example: `dc1-lnd.example.com`
 
 * `password` - (Required) Password for the user used to authenticate with the cloud Account
 
 * `username` - (Required) Username to authenticate with the cloud account
 
 ## Attribute Reference
+
 * `regions` - A set of datacenter managed object reference identifiers to enable provisioning on. Example: `["Datacenter:datacenter-2"]`

--- a/website/docs/d/vra_security_group.html.markdown
+++ b/website/docs/d/vra_security_group.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_security_group"
+page_title: "VMware Aria Automation: vra_security_group"
 description: |-
   Provides a data lookup for security groups.
 ---
 
 # Data Source: vra_security_group
+
 ## Example Usages
+
 This is an example of how to lookup security groups.
 
 **Security groups by filter query:**
@@ -21,7 +23,8 @@ data "vra_security_group" "this" {
 A Security group supports the following arguments:
 
 ## Argument Reference
-* `filter` - (Required) Search criteria to narrow down the Security groups. 
+
+* `filter` - (Required) Search criteria to narrow down the Security groups.
 
 ## Attribute Reference
 
@@ -35,7 +38,7 @@ A Security group supports the following arguments:
 
 * `id` - ID of the security group.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - Name of the security group.
 

--- a/website/docs/d/vra_storage_profile.html.markdown
+++ b/website/docs/d/vra_storage_profile.html.markdown
@@ -1,15 +1,17 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile"
+page_title: "VMware Aria Automation: vra_storage_profile"
 description: |-
   Provides a data lookup for vra_storage_profile.
 ---
 
 # Data Source: vra_storage_profile
+
 ## Example Usages
+
 This is an example of how to create a storage profile data source.
 
-**Storage profile data source by its id:**
+Storage profile data source by its id:
 
 ```hcl
 data "vra_storage_profile" "this" {
@@ -17,7 +19,7 @@ data "vra_storage_profile" "this" {
 }
 ```
 
-**Vra storage profile data source filter by external region id:**
+**storage profile data source filter by external region id:**
 
 ```hcl
 data "vra_storage_profile" "this" {
@@ -28,15 +30,17 @@ data "vra_storage_profile" "this" {
 A storage profile data source supports the following arguments:
 
 ## Argument Reference
+
 * `description` - (Optional) A human-friendly description.
 
 * `disk_properties` - (Optional) Map of storage properties that are to be applied on disk while provisioning.
 
-* `filter` - (Optional) Filter query string that is supported by vRA multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
+* `filter` - (Optional) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
 
 * `id` - (Optional) The id of the image profile instance.
 
 ## Attributes Reference
+
 * `cloud_account_id` - Id of the cloud account this storage profile belongs to.
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
@@ -45,7 +49,7 @@ A storage profile data source supports the following arguments:
 
 * `default_item` - Indicates if this storage profile is a default profile.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -55,7 +59,6 @@ A storage profile data source supports the following arguments:
 
 * `supports_encryption` - Indicates whether this storage profile supports encryption or not.
 
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_storage_profile_aws.html.markdown
+++ b/website/docs/d/vra_storage_profile_aws.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile_aws"
+page_title: "VMware Aria Automation: vra_storage_profile_aws"
 description: |-
   Provides a data lookup for vra_storage_profile_aws.
 ---
 
 # Data Source: vra_storage_profile_aws
+
 ## Example Usages
+
 This is an example of how to create a storage profile aws resource.
 
 **Storage profile aws data source by its id:**
@@ -17,7 +19,7 @@ data "vra_storage_profile_aws" "this" {
 }
 ```
 
-**Vra storage profile data source filter by external region id:**
+**storage profile data source filter by external region id:**
 
 ```hcl
 data "vra_storage_profile_aws" "this" {
@@ -29,7 +31,7 @@ A storage profile aws data source supports the following arguments:
 
 ## Argument Reference
 
-* `filter` - (Optional) Filter query string that is supported by vRA multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
+* `filter` - (Optional) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
 
 * `id` - (Optional) The id of the image profile instance.
 
@@ -41,19 +43,19 @@ A storage profile aws data source supports the following arguments:
 
 * `supports_encryption` - (Optional) Indicates whether this storage profile supports encryption or not.
 
-* `tags` - (Optional) A set of tag keys and optional values that were set on this Network Profile.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - (Optional) A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `volume_type` - (Optional) Indicates the type of volume associated with type of storage.
 
 ## Attributes Reference
+
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
 
 * `default_item` - Indicates if this storage profile is a default profile.
 
 * `external_region_id` - The id of the region as seen in the cloud provider for which this profile is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 

--- a/website/docs/d/vra_storage_profile_azure.html.markdown
+++ b/website/docs/d/vra_storage_profile_azure.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile_azure"
+page_title: "VMware Aria Automation: vra_storage_profile_azure"
 description: |-
   Provides a data lookup for vra_storage_profile_azure.
 ---
 
 # Resource: vra_storage_profile_azure
+
 ## Example Usages
+
 This is an example of how to create a storage profile azure resource.
 
 **Storage profile azure data source by its id:**
@@ -17,7 +19,7 @@ data "vra_storage_profile_azure" "this" {
 }
 ```
 
-**Vra storage profile data source filter by external region id:**
+**storage profile data source filter by external region id:**
 
 ```hcl
 data "vra_storage_profile_azure" "this" {
@@ -29,7 +31,7 @@ A storage profile azure data source supports the following arguments:
 
 ## Argument Reference
 
-* `filter` - (Optional) Filter query string that is supported by vRA multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
+* `filter` - (Optional) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
 
 * `id` - (Optional) The id of the image profile instance.
 
@@ -47,7 +49,7 @@ A storage profile azure data source supports the following arguments:
 
 * `external_region_id` - The id of the region as seen in the cloud provider for which this profile is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -63,7 +65,6 @@ A storage profile azure data source supports the following arguments:
 
 * `region_id` - A link to the region that is associated with the storage profile.
 
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-                      example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_storage_profile_vsphere.html.markdown
+++ b/website/docs/d/vra_storage_profile_vsphere.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile_vsphere"
+page_title: "VMware Aria Automation: vra_storage_profile_vsphere"
 description: |-
   Provides a data lookup for vra_storage_profile_vsphere.
 ---
 
 # Data Source: vra_storage_profile_vsphere
+
 ## Example Usages
+
 This is an example of how to create a storage profile vsphere data source.
 
 **Storage profile vsphere data source by its id:**
@@ -17,7 +19,7 @@ data "vra_storage_profile_vsphere" "this" {
 }
 ```
 
-**Vra storage profile data source filter by external region id:**
+**storage profile data source filter by external region id:**
 
 ```hcl
 data "vra_storage_profile_vsphere" "this" {
@@ -29,13 +31,14 @@ A storage profile vsphere data source supports the following arguments:
 
 ## Argument Reference
 
-* `filter` - (Optional) Filter query string that is supported by vRA multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
+* `filter` - (Optional) Filter query string that is supported by VMware Aria Automation multi-cloud IaaS API. Example: `regionId eq '<regionId>' and cloudAccountId eq '<cloudAccountId>'`.
 
 * `id` - (Optional) The id of the image profile instance.
 
 * `shares_level` - (Optional) Indicates whether this storage profile supports encryption or not.
 
 ## Attributes Reference
+
 * `cloud_account_id` - Id of the cloud account this storage profile belongs to.
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
@@ -52,7 +55,7 @@ A storage profile vsphere data source supports the following arguments:
 
 * `limit_iops` - The upper bound for the I/O operations per second allocated for each virtual disk.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -66,7 +69,6 @@ A storage profile vsphere data source supports the following arguments:
 
 * `supports_encryption` - Indicates whether this storage policy should support encryption or not.
 
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-                      example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/d/vra_zone.html.markdown
+++ b/website/docs/d/vra_zone.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_zone"
+page_title: "VMware Aria Automation: vra_zone"
 description: |-
   Provides a data lookup for vra_zone.
 ---
@@ -41,7 +41,7 @@ A zone data source supports the following arguments:
 
 * `folder` - The folder relative path to the datacenter where resources are deployed to (only applicable for vSphere cloud zones).
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
@@ -50,11 +50,15 @@ A zone data source supports the following arguments:
 * `placement_policy` - The placement policy for the zone. One of `DEFAULT`, `BINPACK`, `SPREAD` or `SPREAD_MEMORY`.
 
 * `tags` - A set of tag keys and optional values that were set on this resource:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `tags_to_match` - A set of tag keys and optional values for compute resource filtering:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/r/vra_block_device.html.markdown
+++ b/website/docs/r/vra_block_device.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_block_device"
+page_title: "VMware Aria Automation: vra_block_device"
 sidebar_current: "docs-vra-resource-block-device"
 description: |-
   Creates a vra_block_device resource.
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: vra_block_device
 
-Creates a VMware vRealize Automation block device resource.
+Creates a VMware Aria Automation block device resource.
 
 ## Example Usages
 
@@ -50,6 +50,7 @@ Create your block device resource with the following arguments:
 * `source_reference` - (Optional) URI to use for block device. Example: `ami-0d4cfd66`
 
 ## Attribute Reference
+
 * `created_at` - Date when entity was created. Date and time format is ISO 8601 and UTC.
 
 * `custom_properties` - Additional custom properties that may be used to extend the machine.
@@ -66,37 +67,37 @@ Create your block device resource with the following arguments:
 
 * `owner` - Email of entity owner.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `snapshots` - Represents a machine snapshot.
 
-    * `created_at` - Date when entity was created. Date and time format is ISO 8601 and UTC.
+  * `created_at` - Date when entity was created. Date and time format is ISO 8601 and UTC.
 
-    * `description` - Describes machine within the scope of your organization and is not propagated to the cloud.
+  * `description` - Describes machine within the scope of your organization and is not propagated to the cloud.
 
-    * `id` - ID of the block device snapshot.
+  * `id` - ID of the block device snapshot.
 
-    * `is_current` - Indicates whether snapshot on block device is current.
+  * `is_current` - Indicates whether snapshot on block device is current.
 
-    * `links` - HATEOAS of the entity
+  * `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
-        * `rel`
+    * `rel`
 
-        * `href`
+    * `href`
 
-        * `hrefs`
+    * `hrefs`
 
-    * `name` - Human-friendly name for block device snapshot.
+  * `name` - Human-friendly name for block device snapshot.
 
-    * `org_id` - ID of organization that block device snapshot belongs to.
+  * `org_id` - ID of organization that block device snapshot belongs to.
 
-    * `owner` - Email of block device snapshot owner.
+  * `owner` - Email of block device snapshot owner.
 
-    * `updated_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.
+  * `updated_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.
 
 * `status` - Status of block device.
 
 * `tags` - Set of tag keys and values to apply to the resource instance.
-Example: `[ { "key" : "vmware.enumeration.type", "value": "nebs_block" } ]`
+           Example: `[ { "key" : "vmware.enumeration.type", "value": "nebs_block" } ]`
 
 * `updated_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.

--- a/website/docs/r/vra_block_device_snapshot.html.markdown
+++ b/website/docs/r/vra_block_device_snapshot.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_block_device_snapshot"
+page_title: "VMware Aria Automation: vra_block_device_snapshot"
 description: |-
-  Creates a VMware vRealize Automation vra_block_device_snapshot resource.
+  Creates a VMware Aria Automation block device snapshot resource.
 ---
 
 # Resource: vra_block_device_snapshot
 
-Creates a VMware vRealize Automation block device snapshot resource.
+Creates a VMware Aria Automation block device snapshot resource.
 
 ## Example Usages
 
@@ -29,11 +29,12 @@ Create your block device snapshot resource with the following arguments:
 * `description` - (Optional) Human-friendly description.
 
 ## Attribute Reference
+
 * `created_at` - Date when entity was created. Date and time format is ISO 8601 and UTC.
 
 * `is_current` - Indicates whether snapshot on block device is current.
 
-* `links` - HATEOAS of entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity
 
 * `name` - Human-friendly name used as an identifier in APIs that support this option.
 
@@ -42,5 +43,3 @@ Create your block device snapshot resource with the following arguments:
 * `owner` - Email of entity owner.
 
 * `update_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.
-
-

--- a/website/docs/r/vra_blueprint.html.markdown
+++ b/website/docs/r/vra_blueprint.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Resource vra_blueprint"
-description: A resource that can be used to create a vRealize Automation cloud template, formerly know as blueprint.
+page_title: "VMware Aria Automation: Resource vra_blueprint"
+description: A resource that can be used to create a VMware Aria Automation cloud template (blueprint).
 ---
 
-# Resource: vra\_blueprint
+# Resource: vra_blueprint
 
-Creates a VMware vRealize Automation (vRA) cloud template resource, formerly known as a blueprint.
+Creates a cloud template (blueprint) resource.
 
 ## Example Usage
 
@@ -15,7 +15,7 @@ The following example shows how to create a blueprint resource.
 ```hcl
 resource "vra_blueprint" "this" {
   name        = var.blueprint_name
-  description = "Created by vRA terraform provider"
+  description = "Created by VMware Aria Automation terraform provider"
 
   project_id = vra_project.this.id
 
@@ -48,14 +48,13 @@ Create your blueprint resource with the following arguments:
 
 * `name` - (Required) Human-friendly name used as an identifier in APIs that support this option.
 
-* `project_id` - (Required) ID of project that entity belongs to. 
+* `project_id` - (Required) ID of project that entity belongs to.
 
 * `request_scope_org` - (Optional) Flag to indicate whether blueprint can be requested from any project in the organization that entity belongs to.
 
-
 ## Attribute Reference
 
-* `content_source_id` - ID of content source. 
+* `content_source_id` - ID of content source.
 
 * `content_source_path` - Content source path.
 
@@ -77,11 +76,11 @@ Create your blueprint resource with the following arguments:
 
 * `project_name` - Name of project that entity belongs to.
 
-* `self_link` - HATEOAS of entity.
+* `self_link` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `status` - Status of cloud template. Supported values: `DRAFT`, `VERSIONED`, `RELEASED`.
 
-* `total_released_versions` - Total number of released versions. 
+* `total_released_versions` - Total number of released versions.
 
 * `total_versions` - Total number of versions.
 
@@ -92,16 +91,16 @@ Create your blueprint resource with the following arguments:
 * `valid` - Flag to indicate if the current content of the cloud template/blueprint is valid.
 
 * `validation_messages` - List of validations messages.
-    * message - Validation message.
-    
-    * metadata - Validation metadata.
-    
-    * path - Validation path.
-    
-    * resource_name - Name of resource.
-    
-    * type - Message type. Supported values: `INFO`, `WARNING`, `ERROR`.
 
+  * `message` - Validation message.
+
+  * `metadata` - Validation metadata.
+
+  * `path` - Validation path.
+
+  * `resource_name` - Name of resource.
+
+  * `type` - Message type. Supported values: `INFO`, `WARNING`, `ERROR`.
 
 ## Import
 

--- a/website/docs/r/vra_blueprint_version.html.markdown
+++ b/website/docs/r/vra_blueprint_version.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Resource vra_blueprint_version"
-description: A resource that can be used to create a vRealize Automation cloud template version.
+page_title: "VMware Aria Automation: Resource vra_blueprint_version"
+description: A resource that can be used to create a VMware Aria Automation cloud template version.
 ---
 
-# Resource: vra\_blueprint\_version
+# Resource: vra_blueprint_version
 
-Creates a VMware vRealize Automation cloud template (blueprint) version resource.
+Creates a VMware Aria Automation cloud template (blueprint) version resource.
 
 ## Example Usages
 
@@ -16,7 +16,7 @@ The following example shows how to create a cloud template (blueprint) version r
 resource "vra_blueprint_version" "this" {
   blueprint_id = var.vra_blueprint_id
   change_log   = "First version"
-  description  = "Released from vRA terraform provider"
+  description  = "Released from VMware Aria Automation terraform provider"
   release      = true
   version      = (random_integer.suffix.result / random_integer.suffix.result)
 }
@@ -30,12 +30,11 @@ Create your cloud template (blueprint) version resource with the following argum
 
 * `change_log` - (Optional) Cloud template  (blueprint) version log.
 
-* `description` - (Optional) Human-friendly description for the cloud template  (blueprint) version. 
- 
+* `description` - (Optional) Human-friendly description for the cloud template  (blueprint) version.
+
 * `release` - (Optional) Flag to indicate whether to release the version.
 
 * `version` - (Required) Cloud template  (blueprint) version.
-
 
 ## Attribute Reference
 

--- a/website/docs/r/vra_catalog_item_entitlement.html.markdown
+++ b/website/docs/r/vra_catalog_item_entitlement.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_catalog_item_entitlement"
-description: A resource that can be used to create a vRealize Automation catalog item entitlement.
+page_title: "VMware Aria Automation: vra_catalog_item_entitlement"
+description: A resource that can be used to create a VMware Aria Automation catalog item entitlement.
 ---
 
-# Resource: vra\_catalog\_item\_entitlement
+# Resource: vra_catalog_item_entitlement
 
 > **Note**:  Deprecated - please use `vra_content_sharing_policy` instead.
 
-This resource provides a way to create a catalog item entitlement in VMware vRealize Automation.
+This resource provides a way to create a catalog item entitlement in VMware Aria Automation.
 
 ## Example Usages
 
@@ -29,21 +29,21 @@ resource "vra_catalog_item_entitlement" "this" {
 
 * `definition` - Represents a catalog item that is linked to a project via an entitlement.
 
-    * `description` - Description of the catalog item.
+  * `description` - Description of the catalog item.
 
-    * `icon_id` - Icon id of associated catalog item.
+  * `icon_id` - Icon id of associated catalog item.
 
-    * `id` - Id of the catalog item.
+  * `id` - Id of the catalog item.
 
-    * `name` - Name of the catalog item.
+  * `name` - Name of the catalog item.
 
-    * `number_of_items` - Number of items in the associated catalog source.
+  * `number_of_items` - Number of items in the associated catalog source.
 
-    * `source_name` - Catalog source name.
+  * `source_name` - Catalog source name.
 
-    * `source_type` - Catalog source type.
+  * `source_type` - Catalog source type.
 
-    * `type` - Content definition type.
+  * `type` - Content definition type.
 
 ## Import
 

--- a/website/docs/r/vra_catalog_source_blueprint.html.markdown
+++ b/website/docs/r/vra_catalog_source_blueprint.html.markdown
@@ -1,16 +1,16 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Resource vra_catalog_source_blueprint"
-description: A resource that can be used to create a vRealize Automation catalog source of type cloud template (blueprint).
+page_title: "VMware Aria Automation: Resource vra_catalog_source_blueprint"
+description: A resource that can be used to create a catalog source of type cloud template (blueprint).
 ---
 
-# Resource: vra\_catalog\_source\_blueprint
+# Resource: vra_catalog_source_blueprint
 
-Creates a VMware vRealize Automation catalog source resource of type cloud template, formerly known as a blueprint.
+Creates a catalog source resource of type cloud template (blueprint).
 
 ## Example Usages
 
-The following example shows how to create a catalog source resource. 
+The following example shows how to create a catalog source resource.
 
 ```hcl
 resource "vra_catalog_source_blueprint" "this" {
@@ -18,7 +18,6 @@ resource "vra_catalog_source_blueprint" "this" {
   project_id = var.vra_project_id
 }
 ```
-
 
 ## Argument Reference
 
@@ -30,10 +29,9 @@ Create your catalog resource with the following arguments:
 
 * `name` - (Required) Human-friendly name used as an identifier in APIs that support this option.
 
-* `project_id` - (Required) ID of the project this entity belongs to. 
+* `project_id` - (Required) ID of the project this entity belongs to.
 
-
-## Attribute Reference 
+## Attribute Reference
 
 * `created_at` - Date when entity was created. Date and time format is ISO 8601 and UTC.
 
@@ -53,10 +51,9 @@ Create your catalog resource with the following arguments:
 
 * `last_import_started_at` - Time at which the last import started.
 
-* `last_updated_by` - User who last updated the catalog source. 
+* `last_updated_by` - User who last updated the catalog source.
 
 * `type_id` - Type of catalog source. Example: `blueprint`, `CFT`, etc.
-
 
 ## Import
 

--- a/website/docs/r/vra_catalog_source_entitlement.html.markdown
+++ b/website/docs/r/vra_catalog_source_entitlement.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_catalog_source_entitlement"
-description: A resource that can be used to create a vRealize Automation catalog source entitlement.
+page_title: "VMware Aria Automation: vra_catalog_source_entitlement"
+description: A resource that can be used to create a VMware Aria Automation catalog source entitlement.
 ---
 
-# Resource: vra\_catalog\_source\_entitlement
+# Resource: vra_catalog_source_entitlement
 
 > **Note**:  Deprecated - please use `vra_content_sharing_policy` instead.
 
-This resource provides a way to create a catalog source entitlement in VMware vRealize Automation.
+This resource provides a way to create a catalog source entitlement in VMware Aria Automation.
 
 ## Example Usages
 
@@ -23,27 +23,27 @@ resource "vra_catalog_source_entitlement" "this" {
 
 * `catalog_source_id` - (Required) The id of the catalog source to create the entitlement.
 
-* `project_id` - (Required) The id of the project this entity belongs to. 
+* `project_id` - (Required) The id of the project this entity belongs to.
 
-## Attribute Reference 
+## Attribute Reference
 
 * `definition` - Represents a catalog source that is linked to a project via an entitlement.
 
-    * `description` - Description of the catalog source.
+  * `description` - Description of the catalog source.
 
-    * `icon_id` - Icon id of associated catalog source.
+  * `icon_id` - Icon id of associated catalog source.
 
-    * `id` - Id of the catalog source.
+  * `id` - Id of the catalog source.
 
-    * `name` - Name of the catalog source.
+  * `name` - Name of the catalog source.
 
-    * `number_of_items` - Number of items in the associated catalog source.
+  * `number_of_items` - Number of items in the associated catalog source.
 
-    * `source_name` - Catalog source name.
+  * `source_name` - Catalog source name.
 
-    * `source_type` - Catalog source type.
+  * `source_type` - Catalog source type.
 
-    * `type` - Content definition type.
+  * `type` - Content definition type.
 
 ## Import
 

--- a/website/docs/r/vra_cloud_account_aws.html.markdown
+++ b/website/docs/r/vra_cloud_account_aws.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_aws"
+page_title: "VMware Aria Automation: vra_cloud_account_aws"
 description: |-
   Creates a vra_cloud_account_aws resource.
 ---
 
-# Resource: vra\_cloud\_account\_aws
+# Resource: vra_cloud_account_aws
 
-Creates a VMware vRealize Automation AWS cloud account resource.
+Creates a VMware Aria Automation AWS cloud account resource.
 
 ## Example Usages
 
@@ -42,10 +42,7 @@ Create your AWS cloud account resource with the following arguments:
 
 * `secret_key` - (Required) AWS Secret Access Key
 
-* `tags` - (Optional) Set of tag keys and values to apply to the cloud account.
-Example: `[ { "key" : "vmware", "value": "provider" } ]`
-
-
+* `tags` - (Optional) Set of tag keys and values to apply to the cloud account. Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 ## Attribute Reference
 
@@ -53,14 +50,13 @@ Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `id` - ID of AWS cloud account.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - ID of organization that entity belongs to.
 
 * `owner` - Email of entity owner.
 
 * `updated_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_cloud_account_azure.html.markdown
+++ b/website/docs/r/vra_cloud_account_azure.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_azure"
+page_title: "VMware Aria Automation: vra_cloud_account_azure"
 description: |-
   Creates a vra_cloud_account_azure resource.
 ---
 
-# Resource: vra\_cloud\_account\_azure
+# Resource: vra_cloud_account_azure
 
-Creates a VMware vRealize Automation Azure cloud account resource.
+Creates a VMware Aria Automation Azure cloud account resource.
 
 ## Example Usages
 
@@ -41,8 +41,7 @@ Create your Azure cloud account resource with the following arguments:
 
 * `subscription_id` - (Required) Azure Subscription ID.
 
-* `tags` - (Optional) Set of tag keys and values to apply to the cloud account.
-Example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - (Optional) Set of tag keys and values to apply to the cloud account. Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `tenant_id` - (Required) Azure Tenant ID.
 
@@ -50,7 +49,7 @@ Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `created_at` - Date when entity was created. Date and time format is ISO 8601 and UTC.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - ID of organization that entity belongs to.
 

--- a/website/docs/r/vra_cloud_account_gcp.html.markdown
+++ b/website/docs/r/vra_cloud_account_gcp.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_gcp"
+page_title: "VMware Aria Automation: vra_cloud_account_gcp"
 description: |-
     Creates a vra_cloud_account_gcp resource.
 ---
 
-# Resource: vra\_cloud\_account\_gcp
+# Resource: vra_cloud_account_gcp
 
-Creates a VMware vRealize Automation GCP cloud account resource.
+Creates a VMware Aria Automation GCP cloud account resource.
 
 ## Example Usages
 
@@ -48,8 +48,7 @@ Create your GCP cloud account resource with the following arguments:
 
 * `project_id` - (Required) GCP Project ID.
 
-* `tags` - (Optional) Set of tag keys and values to apply to the cloud account.
-Example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - (Optional) Set of tag keys and values to apply to the cloud account. Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 ## Attribute Reference
 
@@ -57,14 +56,13 @@ Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `id` - ID of GCP cloud account.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - ID of organization that entity belongs to.
 
 * `owner` - Email of entity owner.
 
 * `updated_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_cloud_account_nsxt.html.markdown
+++ b/website/docs/r/vra_cloud_account_nsxt.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_nsxt"
+page_title: "VMware Aria Automation: vra_cloud_account_nsxt"
 description: |-
     Creates a vra_cloud_account_nsxt resource.
 ---
 
-# Resource: vra\_cloud\_account\_nsxt
+# Resource: vra_cloud_account_nsxt
 
-Creates a VMware vRealize Automation NSX-T cloud account resource.
+Creates a VMware Aria Automation NSX-T cloud account resource.
 
 ## Example Usages
 
@@ -47,8 +47,7 @@ Create your NSX-T cloud account resource with the following arguments:
 
 * `password` - (Required) Password used to authenticate to the cloud Account.
 
-* `tags` - (Optional) Set of tag keys and values to apply to the cloud account.
-Example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - (Optional) Set of tag keys and values to apply to the cloud account. Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `username` - (Required) Username used to authenticate to the cloud account.
 
@@ -60,14 +59,13 @@ Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `id` - ID of NSX-T cloud account.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - ID of organization that entity belongs to.
 
 * `owner` - Email of entity owner.
 
 * `updated_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_cloud_account_nsxv.html.markdown
+++ b/website/docs/r/vra_cloud_account_nsxv.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_nsxv"
+page_title: "VMware Aria Automation: vra_cloud_account_nsxv"
 description: |-
     Creates a vra_cloud_account_nsxv resource.
 ---
 
-# Resource: vra\_cloud\_account\_nsxv
+# Resource: vra_cloud_account_nsxv
 
-Creates a VMware vRealize Automation NSX-V cloud account resource.
+Creates a VMware Aria Automation NSX-V cloud account resource.
 
 ## Example Usages
 
@@ -47,8 +47,7 @@ Create your NSX-V cloud account resource with the following arguments:
 
 * `password` - (Required) Password used to authenticate to the cloud account.
 
-* `tags` - (Optional) Set of tag keys and values to apply to the cloud account.  
-Example: [ { "key" : "vmware", "value": "provider" } ]
+* `tags` - (Optional) Set of tag keys and values to apply to the cloud account. Example: [ { "key" : "vmware", "value": "provider" } ]
 
 * `username` - (Required) Username used to authenticate with the cloud account.
 
@@ -60,14 +59,13 @@ Example: [ { "key" : "vmware", "value": "provider" } ]
 
 * `id` - ID of NSX-V cloud account.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - ID of organization that entity belongs to.
 
 * `owner` - Email of entity owner.
 
 * `updated_at` - Date when entity was last updated. Date and time format is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_cloud_account_vmc.html.markdown
+++ b/website/docs/r/vra_cloud_account_vmc.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_vmc"
+page_title: "VMware Aria Automation: vra_cloud_account_vmc"
 description: |-
     Creates a vra_cloud_account_vmc resource.
 ---
 
-# Resource: vra\_cloud\_account\_vmc
+# Resource: vra_cloud_account_vmc
 
-Creates a VMware vRealize Automation VMC cloud account resource.
+Creates a VMware Aria Automation VMC cloud account resource.
 
 ## Example Usages
 
@@ -26,7 +26,7 @@ resource "vra_cloud_account_vmc" "this" {
   vcenter_password = var.vcenter_password
   vcenter_username = var.vcenter_username
   nsx_hostname     = var.nsx_hostname
-  dc_id            = var.data_collector_id  // Required for vRA Cloud, Optional for vRA on-prem
+  dc_id            = var.data_collector_id  // Required for VMware Aria Automation Cloud, Optional for VMware Aria Automation on-prem
   regions                 = var.regions
 
   accept_self_signed_cert = true
@@ -58,8 +58,7 @@ Create your VMC cloud account resource with the following arguments:
 
 * `sddc_name` - (Required) Identifier of the on-premise SDDC to be used by the cloud account. Note that NSX-V SDDCs are not supported.
 
-* `tags` - (Optional) Set of tag keys and values to apply to the cloud account.
-Example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - (Optional) Set of tag keys and values to apply to the cloud account. Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `vcenter_hostname` - (Required) IP address or FQDN of the vCenter Server in the specified SDDC. The cloud proxy belongs on this vCenter.
 
@@ -73,14 +72,13 @@ Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `id` - ID of the VMC cloud account.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - ID of organization that entity belongs to.
 
 * `owner` - Email of entity owner.
 
 * `updated_at` - Date when the entity was last updated. Date and time format is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_cloud_account_vsphere.html.markdown
+++ b/website/docs/r/vra_cloud_account_vsphere.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_cloud_account_vsphere"
+page_title: "VMware Aria Automation: vra_cloud_account_vsphere"
 description: |-
     Creates a vra_cloud_account_vsphere resource.
 ---
 
-# Resource: vra\_cloud\_account\_vsphere
+# Resource: vra_cloud_account_vsphere
 
-Creates a VMware vRealize Automation vSphere cloud account resource.
+Creates a VMware Aria Automation vSphere cloud account resource.
 
 ## Example Usages
 
@@ -20,7 +20,7 @@ resource "vra_cloud_account_vsphere" "this" {
   username    = var.username
   password    = var.password
   hostname    = var.hostname
-  dc_id       = var.vra_data_collector_id // Required for vRA Cloud, Optional for vRA 8.X
+  dc_id       = var.vra_data_collector_id // Required for VMware Aria Automation Cloud, Optional for VMware Aria Automation 8.X
   regions                      = var.regions
   associated_cloud_account_ids = [var.vra_cloud_account_nsxt_id]
 
@@ -51,8 +51,7 @@ Create your vSphere cloud account resource with the following arguments:
 
 * `regions` - (Required) A set of region names that are enabled for the cloud account.
 
-* `tags` - (Optional) A set of tag keys and optional values to apply to the cloud account.
-Example: `[ { "key" : "vmware", "value": "provider" } ]`
+* `tags` - (Optional) A set of tag keys and optional values to apply to the cloud account. Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `username` - (Required) vSphere username used to authenticate to the cloud account.
 
@@ -64,14 +63,13 @@ Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `id` - (Optional) ID of the vSphere cloud account.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - ID of organization that entity belongs to.
 
 * `owner` - Email of entity owner.
 
 * `updated_at` - Date when the entity was last updated. Date and time format is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_content_sharing_policy.html.markdown
+++ b/website/docs/r/vra_content_sharing_policy.html.markdown
@@ -1,16 +1,16 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_content_sharing_policy"
+page_title: "VMware Aria Automation: vra_content_sharing_policy"
 description: Creates a vra_content_sharing_policy resource.
 ---
 
-# Resource: vra\_content\_sharing\_policy
+# Resource: vra_content_sharing_policy
 
-Creates a VMware vRealize Automation Content Sharing Policy resource.
+Creates a VMware Aria Automation content sharing policy resource.
 
 ## Example Usages
 
-The following example shows how to create a Content Sharing Policy resource:
+The following example shows how to create a content sharing policy resource:
 
 ```hcl
 resource "vra_content_sharing_policy" "this" {

--- a/website/docs/r/vra_content_source.html.markdown
+++ b/website/docs/r/vra_content_source.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Resource vra_content_source"
-description: A resource that can be used to create a content source in vRealize Automation(vRA).
+page_title: "VMware Aria Automation: Resource vra_content_source"
+description: A resource that can be used to create a content source in VMware Aria Automation.
 ---
 
-# Resource: vra\_content_source
+# Resource: vra_content_source
 
-This resource provides a way to create a content source vRealize Automation(vRA).
+This resource provides a way to create a content source VMware Aria Automation.
 
 ## Example Usages
 
@@ -33,22 +33,21 @@ resource "vra_content_source" "this" {
 }
 ```
 
-
 ## Argument Reference
 
 * `config` - (Required) Content source custom configuration.
 
-    * `branch` - Content source branch name.
-    
-    * `content_type` - Content source type. Supported values are `BLUEPRINT`, `IMAGE`, `ABX_SCRIPTS`, `TERRAFORM_CONFIGURATION`.
-    
-    * `integration_id` - Content source integration id as seen in vRA integrations. 
-    
-    * `path` - Path to refer to in the content source repository and branch.
-    
-    * `project_name` - Name of the project.
-    
-    * `repository` - Content source repository.
+  * `branch` - Content source branch name.
+
+  * `content_type` - Content source type. Supported values are `BLUEPRINT`, `IMAGE`, `ABX_SCRIPTS`, `TERRAFORM_CONFIGURATION`.
+
+  * `integration_id` - Content source integration id as seen integrations.
+
+  * `path` - Path to refer to in the content source repository and branch.
+
+  * `project_name` - Name of the project.
+
+  * `repository` - Content source repository.
 
 * `description` - (Optional) A human-friendly description.
 
@@ -59,7 +58,6 @@ resource "vra_content_source" "this" {
 * `sync_enabled` - (Required) Flag indicating whether sync is enabled for this content source.
 
 * `type_id` - (Required) Content Source type. Supported values are `com.gitlab`, `com.github`, `com.vmware.marketplace`, `org.bitbucket`.
-
 
 ## Attribute Reference
 
@@ -74,7 +72,6 @@ resource "vra_content_source" "this" {
 * `last_updated_by` - The user the entity was last updated by.
 
 * `org_id` - The id of the organization this entity belongs to.
-
 
 ## Import
 

--- a/website/docs/r/vra_deployment.html.markdown
+++ b/website/docs/r/vra_deployment.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: Resource vra_deployment"
-description: A resource that can be used to create a vRealize Automation deployment.
+page_title: "VMware Aria Automation: Resource vra_deployment"
+description: A resource that can be used to create a VMware Aria Automation deployment.
 ---
 
-# Resource: vra\_deployment
+# Resource: vra_deployment
 
-This resource provides a way to create a deployment in vRealize Automation(vRA) by either using a blueprint, or catalog item, or an inline blueprint.
+This resource provides a way to create a deployment in VMware Aria Automation by either using a cloud template (blueprint), or catalog item, or an inline blueprint.
 
 ## Example Usages
 
@@ -110,72 +110,72 @@ resource "vra_deployment" "this" {
 
 * `created_by` - The user the entity was created by.
 
-* `expense` - Expense incurred for the deployment. 
+* `expense` - Expense incurred for the deployment.
 
-    * `additional_expense` - Additional expense incurred for the resource.
-    
-    * `code` - Expense sync message code if any.
-    
-    * `compute_expense` - Compute expense of the entity.
-    
-    * `last_update_time` - Last expense sync time.
-    
-    * `message` - Expense sync message if any.
-    
-    * `network_expense` - Network expense of the entity.
-    
-    * `storage_expense` - Storage expense of the entity.
-    
-    * `total_expense` - Total expense of the entity.
-    
-    * `unit` - Monetary unit.
-    
+  * `additional_expense` - Additional expense incurred for the resource.
+
+  * `code` - Expense sync message code if any.
+
+  * `compute_expense` - Compute expense of the entity.
+
+  * `last_update_time` - Last expense sync time.
+
+  * `message` - Expense sync message if any.
+
+  * `network_expense` - Network expense of the entity.
+
+  * `storage_expense` - Storage expense of the entity.
+
+  * `total_expense` - Total expense of the entity.
+
+  * `unit` - Monetary unit.
+
 * `id` - The id of the deployment.
 
 * `inputs_including_defaults` - All the inputs applied during last create/update operation, including those with default values. For the list of inputs provided by the user in the configuration, refer to `inputs`.
 
 * `last_request` - Represents deployment requests.
 
-    * `action_id` - Identifier of the requested action.
-    
-    * `approved_at` - Time at which the request was approved.
-    
-    * `blueprint_id` - Identifier of the requested blueprint in the form ‘UUID:version’.
-    
-    * `cancelable` - Indicates whether request can be canceled or not. 
-    
-    * `catalog_item_id` - Identifier of the requested catalog item in the form ‘UUID:version’.
-    
-    * `completed_at` - Time at which the request completed.
-    
-    * `completed_tasks` - The number of tasks completed while fulfilling this request.
-    
-    * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
-    
-    * `details` - Longer user-friendly details of the request.
- 
-    * `dismissed` - Indicates whether request is in dismissed state.
-     
-    * `id` - Request identifier.
- 
-    * `initialized_at` - Time at which the request was initialized.
+  * `action_id` - Identifier of the requested action.
 
-    * `inputs` - List of request inputs.
-    
-    * `name` - Short user-friendly label of the request (e.g. ‘shuting down myVM’).
-    
-    * `outputs` - Request outputs.
-    
-    * `requested_by` - The user that initiated the request.
-     
-    * `resource_name` - Optional resource name to which the request applies to.
- 
-    * `status` - Request overall execution status. Supported values: `CREATED`, `PENDING`, `INITIALIZATION`, `CHECKING_APPROVAL`, `APPROVAL_PENDING`, `INPROGRESS`, `COMPLETION`, `APPROVAL_REJECTED`, `ABORTED`, `SUCCESSFUL`, `FAILED`.
+  * `approved_at` - Time at which the request was approved.
 
-    * `total_tasks` -The total number of tasks need to be completed to fulfil this request.
+  * `blueprint_id` - Identifier of the requested blueprint in the form ‘UUID:version’.
 
-    * `updated_at` - Last update time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
-    
+  * `cancelable` - Indicates whether request can be canceled or not.
+
+  * `catalog_item_id` - Identifier of the requested catalog item in the form ‘UUID:version’.
+
+  * `completed_at` - Time at which the request completed.
+
+  * `completed_tasks` - The number of tasks completed while fulfilling this request.
+
+  * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
+
+  * `details` - Longer user-friendly details of the request.
+
+  * `dismissed` - Indicates whether request is in dismissed state.
+
+  * `id` - Request identifier.
+
+  * `initialized_at` - Time at which the request was initialized.
+
+  * `inputs` - List of request inputs.
+
+  * `name` - Short user-friendly label of the request (e.g. ‘shuting down myVM’).
+
+  * `outputs` - Request outputs.
+
+  * `requested_by` - The user that initiated the request.
+
+  * `resource_name` - Optional resource name to which the request applies to.
+
+  * `status` - Request overall execution status. Supported values: `CREATED`, `PENDING`, `INITIALIZATION`, `CHECKING_APPROVAL`, `APPROVAL_PENDING`, `INPROGRESS`, `COMPLETION`, `APPROVAL_REJECTED`, `ABORTED`, `SUCCESSFUL`, `FAILED`.
+
+  * `total_tasks` -The total number of tasks need to be completed to fulfil this request.
+
+  * `updated_at` - Last update time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
+
 * `last_updated_at` - TDate when the entity was last updated. The date is in ISO 6801 and UTC.
 
 * `last_updated_by` - The user that last updated the deployment.
@@ -186,53 +186,53 @@ resource "vra_deployment" "this" {
 
 * `project` - The project this entity belongs to.
 
-    * `description` - A human friendly description.
-    
-    * `id` - Id of the entity.
-    
-    * `name` - Name of the entity.
-    
-    * `version` - Version of the entity, if applicable.
+  * `description` - A human friendly description.
+
+  * `id` - Id of the entity.
+
+  * `name` - Name of the entity.
+
+  * `version` - Version of the entity, if applicable.
 
 * `resources` - Expanded resources for the deployment. Content of this property will not be maintained backward compatible.
 
-    * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
-    
-    * `depends_on` - A list of other resources this resource depends on.
-    
-    * `description` - A description of the resource.
-    
-    `expense` - Expense incurred for this resource. 
-    
+  * `created_at` - Creation time (e.g. date format ‘2019-07-13T23:16:49.310Z’).
+
+  * `depends_on` - A list of other resources this resource depends on.
+
+  * `description` - A description of the resource.
+
+    `expense` - Expense incurred for this resource.
+
         * `additional_expense` - Additional expense incurred for the resource.
-        
+
         * `code` - Expense sync message code if any.
-        
+
         * `compute_expense` - Compute expense of the entity.
-        
+
         * `last_update_time` - Last expense sync time.
-        
+
         * `message` - Expense sync message if any.
-        
+
         * `network_expense` - Network expense of the entity.
-        
+
         * `storage_expense` - Storage expense of the entity.
-        
+
         * `total_expense` - Total expense of the entity.
-        
+
         * `unit` - Monetary unit.
-    
-    * `id` - Unique identifier of the resource.
-    
-    * `name` - Name of the resource.
-    
-    * `properties_json` - List of properties in the encoded JSON string format. 
-    
-    * `state` - The current state of the resource. Supported values are `PARTIAL`, `TAINTED`, `OK.`
-    
-    * `sync_status` - The current sync status. Supported values are `SUCCESS`, `MISSING`, `STALE`.
-    
-    * `type` - Type of the resource.
+
+  * `id` - Unique identifier of the resource.
+
+  * `name` - Name of the resource.
+
+  * `properties_json` - List of properties in the encoded JSON string format.
+
+  * `state` - The current state of the resource. Supported values are `PARTIAL`, `TAINTED`, `OK.`
+
+  * `sync_status` - The current sync status. Supported values are `SUCCESS`, `MISSING`, `STALE`.
+
+  * `type` - Type of the resource.
 
 * `status` - The status of the deployment with respect to its life cycle operations.
 

--- a/website/docs/r/vra_fabric_compute.html.markdown
+++ b/website/docs/r/vra_fabric_compute.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_compute"
+page_title: "VMware Aria Automation: vra_fabric_compute"
 description: |-
   Updates a fabric_compute resource.
 ---
 
 # Resource: vra_fabric_compute
 
-Updates a VMware vRealize Automation fabric_compute resource.
+Updates a VMware Aria Automation fabric_compute resource.
 
 ## Example Usages
 
@@ -23,10 +23,13 @@ resource "vra_fabric_compute" "this" {
   }
 }
 ```
+
 ## Argument Reference
 
 * `tags` -  A set of tag keys and optional values that were set on this resource:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 ## Attribute Reference
@@ -45,7 +48,7 @@ resource "vra_fabric_compute" "this" {
 
 * `lifecycle_state` - Lifecycle status of the compute instance.
 
-* `links` - HATEOAS of the entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier for the fabric compute resource instance.
 

--- a/website/docs/r/vra_fabric_datastore_vsphere.html.markdown
+++ b/website/docs/r/vra_fabric_datastore_vsphere.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_datastore_vsphere"
+page_title: "VMware Aria Automation: vra_fabric_datastore_vsphere"
 description: |-
   Updates a fabric_datastore_vsphere resource.
 ---
 
 # Resource: vra_fabric_datastore_vsphere
 
-Updates a VMware vRealize Automation fabric_datastore_vsphere resource.
+Updates a VMware Aria Automation fabric_datastore_vsphere resource.
 
 ## Example Usages
 
@@ -23,10 +23,13 @@ resource "vra_fabric_datastore_vsphere" "this" {
   }
 }
 ```
+
 ## Argument Reference
 
 * `tags` -  A set of tag keys and optional values that were set on this resource:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 ## Attribute Reference
@@ -43,7 +46,7 @@ resource "vra_fabric_datastore_vsphere" "this" {
 
 * `free_size_gb` - Indicates free size available in datastore.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier for the vSphere fabric datastore resource instance.
 
@@ -52,7 +55,9 @@ resource "vra_fabric_datastore_vsphere" "this" {
 * `owner` - Email of the user that owns the entity.
 
 * `tags` -  A set of tag keys and optional values that were set on this resource:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `type` - Type of datastore.
@@ -63,4 +68,4 @@ resource "vra_fabric_datastore_vsphere" "this" {
 
 To import the fabric datastore vSphere resource, use the ID as in the following example:
 
-`$ terraform import vra_fabric_datastore_vsphere.this 8e0c9a4c-3ab8-48e8-b9d5-0751c871e282
+`$ terraform import vra_fabric_datastore_vsphere.this 8e0c9a4c-3ab8-48e8-b9d5-0751c871e282`

--- a/website/docs/r/vra_fabric_network_vsphere.html.markdown
+++ b/website/docs/r/vra_fabric_network_vsphere.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_fabric_network_vsphere"
+page_title: "VMware Aria Automation: vra_fabric_network_vsphere"
 description: |-
   Updates a fabric_network_vsphere resource.
 ---
 
 # Resource: vra_fabric_network_vsphere
 
-Updates a VMware vRealize Automation fabric_network_vsphere resource.
+Updates a VMware Aria Automation fabric_network_vsphere resource.
 
 ## Example Usages
 
@@ -15,7 +15,6 @@ You cannot create a vSphere fabric network resource, however you can import usin
 Once a resource is imported, you can update it as shown below:
 
 ```hcl
-
 resource "vra_fabric_network_vsphere" "simple" {
   cidr            = var.cidr
   default_gateway = var.gateway
@@ -25,8 +24,8 @@ resource "vra_fabric_network_vsphere" "simple" {
     value = "bar"
   }
 }
-
 ```
+
 ## Argument Reference
 
 * `cidr` - Network CIDR to be used.
@@ -48,6 +47,7 @@ resource "vra_fabric_network_vsphere" "simple" {
 * `is_public` - Indicates whether the sub-network supports public IP assignment.
 
 ## Attribute Reference
+
 * `cloud_account_ids` - Set of ids of the cloud accounts this entity belongs to.
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
@@ -56,9 +56,9 @@ resource "vra_fabric_network_vsphere" "simple" {
 
 * `external_region_id` - The id of the region for which this network is defined.
 
-* `id` - ID of the vRA fabric network.
+* `id` - ID of the VMware Aria Automation fabric network.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -68,7 +68,6 @@ resource "vra_fabric_network_vsphere" "simple" {
             Example: `[ { "key" : "vmware", "value": "provider" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_flavor_profile.html.markdown
+++ b/website/docs/r/vra_flavor_profile.html.markdown
@@ -1,45 +1,47 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_flavor_profile"
+page_title: "VMware Aria Automation: vra_flavor_profile"
 description: |-
   Provides a data lookup for vra_flavor_profile.
 ---
 
 # Resource: vra_flavor_profile
+
 ## Example Usages
+
 This is an example of how to create a flavor profile resource.
 
 **Flavor profile:**
 
 ```hcl
 resource "vra_flavor_profile" "my-aws-flavor-profile" {
-	name = "AWS"
-	description = "My AWS flavor"
-	region_id = "${data.vra_region.aws.id}"
-	flavor_mapping {
-		name = "small"
-		instance_type = "t2.small"
-	}
-	flavor_mapping {
-		name = "medium"
-		instance_type = "t2.medium"
-	}
+ name = "AWS"
+ description = "My AWS flavor"
+ region_id = "${data.vra_region.aws.id}"
+ flavor_mapping {
+  name = "small"
+  instance_type = "t2.small"
+ }
+ flavor_mapping {
+  name = "medium"
+  instance_type = "t2.medium"
+ }
 }
 
 resource "vra_flavor_profile" "my-vsphere-flavor-profile" {
-	name = "vSphere"
-	description = "My vSphere flavor"
-	region_id = "${data.vra_region.vsphere.id}"
-	flavor_mapping {
-		name = "small"
-		cpu_count = 2
-		memory = 2048
-	}
-	flavor_mapping {
-		name = "medium"
-		cpu_count = 4
-		memory = 4096
-	}
+ name = "vSphere"
+ description = "My vSphere flavor"
+ region_id = "${data.vra_region.vsphere.id}"
+ flavor_mapping {
+  name = "small"
+  cpu_count = 2
+  memory = 2048
+ }
+ flavor_mapping {
+  name = "medium"
+  cpu_count = 4
+  memory = 4096
+ }
 }
 ```
 
@@ -54,10 +56,14 @@ An flavor profile resource supports the following arguments:
 * `region_id` - (Required) The id of the region for which this profile is defined.
 
 * `flavor_mapping` - (Optional) A list of the flavor mappings defined for the corresponding cloud end-point region.
-	* `name` - (Required) The name of the flavor mapping.
-	* `instance_type` - (Optional) The value of the instance type in the corresponding cloud. Mandatory for public clouds. Only `instance_type` or `cpu_count`/`memory` must be specified.
-	* `cpu_count` - (Optional) Number of CPU cores. Mandatory for private clouds such as vSphere. Only `instance_type` or `cpu_count`/`memory` must be specified.
-	* `memory` - (Optional) Total amount of memory (in megabytes). Mandatory for private clouds such as vSphere. Only `instance_type` or `cpu_count`/`memory` must be specified.
+
+  * `name` - (Required) The name of the flavor mapping.
+
+  * `instance_type` - (Optional) The value of the instance type in the corresponding cloud. Mandatory for public clouds. Only `instance_type` or `cpu_count`/`memory` must be specified.
+
+  * `cpu_count` - (Optional) Number of CPU cores. Mandatory for private clouds such as vSphere. Only `instance_type` or `cpu_count`/`memory` must be specified.
+
+  * `memory` - (Optional) Total amount of memory (in megabytes). Mandatory for private clouds such as vSphere. Only `instance_type` or `cpu_count`/`memory` must be specified.
 
 ## Attribute Reference
 
@@ -67,7 +73,7 @@ An flavor profile resource supports the following arguments:
 
 * `external_region_id` - The id of the region for which this profile is defined.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 

--- a/website/docs/r/vra_image_profile.html.markdown
+++ b/website/docs/r/vra_image_profile.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_image_profile"
+page_title: "VMware Aria Automation: vra_image_profile"
 description: |-
   Provides a data lookup for vra_image_profile.
 ---
 
 # Resource: vra_image_profile
+
 ## Example Usages
+
 This is an example of how to create an image profile resource.
 
 **Image profile:**
@@ -38,7 +40,6 @@ resource "vra_image_profile" "this" {
     cloud_config = "runcmd echo 'Hello'"
   }
 }
-
 ```
 
 An image profile resource supports the following arguments:
@@ -49,13 +50,13 @@ An image profile resource supports the following arguments:
 
 * `name` - (Required) A human-friendly name used as an identifier in APIs that support this option.
 
-* `region_id` - (Required) The id of the region for which this profile is defined as in vRealize Automation(vRA).
+* `region_id` - (Required) The id of the region for which this profile is defined as in VMware Aria Automation.
 
 ## Attributes Reference
 
 * `created_at` - Date when the entity was created. The date is in ISO 6801 and UTC.
 
-* `external_region_id` - The external regionId of the resource. 
+* `external_region_id` - The external regionId of the resource.
 
 * `image_mapping` - Image mapping defined for the corresponding region.
 

--- a/website/docs/r/vra_integration.html.markdown
+++ b/website/docs/r/vra_integration.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_integration"
+page_title: "VMware Aria Automation: vra_integration"
 description: |-
     Creates a vra_integration resource.
 ---
 
-# Resource: vra\_integration
+# Resource: vra_integration
 
-Creates a VMware vRealize Automation Integration resource.
+Creates a VMware Aria Automation Integration resource.
 
 ## Example Usages
 
@@ -61,14 +61,13 @@ Create your integration resource with the following arguments:
 
 * `id` - (Optional) The id of the integration.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
 * `owner` - Email of the user that owns the entity.
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.
-
 
 ## Import
 

--- a/website/docs/r/vra_machine.html.markdown
+++ b/website/docs/r/vra_machine.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_machine"
+page_title: "VMware Aria Automation: vra_machine"
 description: |-
   Creates a vra_machine resource.
 ---
 
 # Resource: vra_machine
 
-Creates a VMware vRealize Automation machine resource.
+Creates a VMware Aria Automation machine resource.
 
 ## Example Usages
 
@@ -16,7 +16,7 @@ The following example shows how to create a machine resource.
 ```hcl
 resource "vra_machine" "this" {
   name        = "tf-machine"
-  description = "terrafrom test machine"
+  description = "terraform test machine"
   project_id  = data.vra_project.this.id
   image       = "ubuntu2"
   flavor      = "medium"
@@ -60,6 +60,7 @@ EOF
   }
 }
 ```
+
 A machine resource supports the following resource:
 
 ## Argument Reference
@@ -68,7 +69,7 @@ Create your machine resource with the following arguments:
 
 * `boot_config` - (Optional)  Machine boot config that will be passed to the instance. Used to perform common automated configuration tasks and even run scripts after instance starts.
 
-    * `content` - (Optional) Calid cloud config data in json-escaped yaml syntax.
+  * `content` - (Optional) Calid cloud config data in json-escaped yaml syntax.
 
 * `custom_properties` - (Optional) Additional properties that may be used to extend the base resource.
 
@@ -78,21 +79,21 @@ Create your machine resource with the following arguments:
 
 * `disks` - (Optional) Specification for attaching/detaching disks to a machine.
 
-    * `block_device_id` - (Required) ID of the existing block device.
+  * `block_device_id` - (Required) ID of the existing block device.
 
-    * `description` - (Optional) Human-friendly description.
+  * `description` - (Optional) Human-friendly description.
 
-    * `name` - (Optional) Human-friendly block-device name used as an identifier in APIs that support this option.
+  * `name` - (Optional) Human-friendly block-device name used as an identifier in APIs that support this option.
 
 * `flavor` - (Required) Flavor of machine instance.
 
 * `image` - (Optional) Type of image used for this machine.
 
-* `image_disk_constraints` - (Optional) Constraints that are used to drive placement policies for the image disk. Constraint expressions are matched against tags on existing placement targets. example: `[{"mandatory" : "true", "expression": "environment:prod"}, {"mandatory" : "false", "expression": "pci"}]`. It is nested argument with the following properties.
+* `image_disk_constraints` - (Optional) Constraints that are used to drive placement policies for the image disk. Constraint expressions are matched against tags on existing placement targets. Example: `[{"mandatory" : "true", "expression": "environment:prod"}, {"mandatory" : "false", "expression": "pci"}]`. It is nested argument with the following properties.
 
-    * `expression` - (Required) Constraint that is conveyed to the policy engine. An expression of the form "[!]tag-key[:[tag-value]]", used to indicate a constraint match on keys and values of tags.
+  * `expression` - (Required) Constraint that is conveyed to the policy engine. An expression of the form "[!]tag-key[:[tag-value]]", used to indicate a constraint match on keys and values of tags.
 
-    * `mandatory` - (Required) Indicates whether this constraint should be strictly enforced or not.
+  * `mandatory` - (Required) Indicates whether this constraint should be strictly enforced or not.
 
 * `image_ref` - (Optional) Direct image reference used for this machine (name, path, location, uri, etc.). Valid if no image property is provided
 
@@ -100,33 +101,32 @@ Create your machine resource with the following arguments:
 
 * `nics` - (Optional) Set of network interface controller specifications for this machine. If not specified, then a default network connection will be created.
 
-    * `addresses` - (Optional) List of IP addresses allocated or in use by this network interface.
-                    example: `[ "10.1.2.190" ]`
+  * `addresses` - (Optional) List of IP addresses allocated or in use by this network interface.
+                    Example: `[ "10.1.2.190" ]`
 
-    * `custom_properties` - (Optional) Additional properties that may be used to extend the base type.
+  * `custom_properties` - (Optional) Additional properties that may be used to extend the base type.
 
-    * `description` - (Optional) Human-friendly description.
+  * `description` - (Optional) Human-friendly description.
 
-    * `device_index` - (Optional) The device index of this network interface.
+  * `device_index` - (Optional) The device index of this network interface.
 
-    * `name` - (Optional) Human-friendly name used as an identifier in APIs that support this option.
+  * `name` - (Optional) Human-friendly name used as an identifier in APIs that support this option.
 
-    * `network_id` - (Required) ID of the network instance that this network interface plugs into.
+  * `network_id` - (Required) ID of the network instance that this network interface plugs into.
 
-    * `security_group_ids` - (Optional) List of security group ids which this network interface will be assigned to.
+  * `security_group_ids` - (Optional) List of security group ids which this network interface will be assigned to.
 
-* `tags` - (Optional) Set of tag keys and optional values that should be set on any resource that is produced from this specification. example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`. It is nested argument with the following properties.
+* `tags` - (Optional) Set of tag keys and optional values that should be set on any resource that is produced from this specification.Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`. It is nested argument with the following properties.
 
-    * `key` - (Required) Tag’s key.
+  * `key` - (Required) Tag’s key.
 
-    * `value` - (Required) Tag’s value.
+  * `value` - (Required) Tag’s value.
 
 ## Attribute Reference
 
 * `address` - Primary address allocated or in use by this machine. The actual type of the address depends on the adapter type. Typically it is either the public or the external IP address.
 
-* `constraints` - Constraints used to drive placement policies for the virtual machine produced from the specification. Constraint expressions are matched against tags on existing placement targets.
-Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandatory" : "false", "expression": "pci"}]`
+* `constraints` - Constraints used to drive placement policies for the virtual machine produced from the specification. Constraint expressions are matched against tags on existing placement targets. Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandatory" : "false", "expression": "pci"}]`
 
 * `created_at` - Date when the entity was created. Date and time format is ISO 8601 and UTC.
 
@@ -134,15 +134,15 @@ Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandato
 
 * `disks_list` - List of all disks attached to a machine including boot disk, and additional block devices attached using the disks attribute.
 
-    * `block_device_id` - ID of existing block device.
+  * `block_device_id` - ID of existing block device.
 
-    * `description` - Human-friendly description.
+  * `description` - Human-friendly description.
 
-    * `name` - Human-friendly block-device name used as an identifier in APIs that support this option.
+  * `name` - Human-friendly block-device name used as an identifier in APIs that support this option.
 
-    * `scsi_controller` - The id of the SCSI controller (_e.g_., `SCSI_Controller_0`.)
+  * `scsi_controller` - The id of the SCSI controller (_e.g_., `SCSI_Controller_0`.)
 
-    * `unit_number` - The unit number of the SCSI controller (_e.g_., `2`.)
+  * `unit_number` - The unit number of the SCSI controller (_e.g_., `2`.)
 
 * `external_id` - External entity ID on the provider side.
 
@@ -150,7 +150,7 @@ Example: `[{"mandatory" : "true", "expression": "environment":"prod"}, {"mandato
 
 * `external_zone_id` - External zoneId of the resource.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `organization_id` - ID of the organization this entity belongs to.
 

--- a/website/docs/r/vra_network.html.markdown
+++ b/website/docs/r/vra_network.html.markdown
@@ -1,11 +1,12 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_network"
+page_title: "VMware Aria Automation: vra_network"
 description: |-
-  Provides a VMware vRA vra_network resource.
+  Provides a vra_network resource.
 ---
 
 # Resource: vra_network
+
 ## Example Usages
 
 This is an example of how to create a network resource.
@@ -15,15 +16,16 @@ resource "vra_network" "my_network" {
   name = "terraform_vra_network-%d"
   outbound_access = false
   tags {
-	key = "foo"
+    key = "foo"
     value = "bar"
   }
   constraints {
-	  mandatory = true
-	  expression = "pci"
+   mandatory = true
+   expression = "pci"
   }
 }
 ```
+
 A network resource supports the following resource:
 
 ## Argument Reference
@@ -50,7 +52,7 @@ A network resource supports the following resource:
 
 * `external_zone_id` - The external zoneId of the resource.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `organization_id` - The id of the organization this entity belongs to.
 
@@ -58,7 +60,6 @@ A network resource supports the following resource:
 
 * `self_link` - Self link of this request.
 
-* `tags` - A set of tag keys and optional values that were set on this resource.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this resource. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `update_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/r/vra_network_ip_range.html.markdown
+++ b/website/docs/r/vra_network_ip_range.html.markdown
@@ -1,22 +1,21 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_network_ip_range"
+page_title: "VMware Aria Automation: vra_network_ip_range"
 description: |-
   Creates a network_ip_range resource.
 ---
 
 # Resource: vra_network_ip_range
 
-Creates a VMware vRealize Automation network_ip_range resource.
+Creates a VMware Aria Automation network_ip_range resource.
 
 ## Example Usages
 
-**Create vRA Network IP range resource:**
+**Create VMware Aria Automation Network IP range resource:**
 
-This is an example of how to create a vRA Network IP range resource.
+This is an example of how to create  Network IP range resource.
 
 ```hcl
-
 resource "vra_network_ip_range" "this" {
   name               = "example-ip-range"
   description        = "Internal Network IP Range Example"
@@ -30,13 +29,11 @@ resource "vra_network_ip_range" "this" {
     value = "bar"
   }
 }
-
 ```
-
 
 ## Argument Reference
 
-The following arguments are supported for a vRA Network IP range resource:
+The following arguments are supported for  Network IP range resource:
 
 * `description` - (Optional) A human-friendly description.
 
@@ -61,7 +58,7 @@ The following arguments are supported for a vRA Network IP range resource:
 
 * `id` - ID of the network IP range
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
@@ -71,6 +68,6 @@ The following arguments are supported for a vRA Network IP range resource:
 
 ## Import
 
-To import the vRA Network IP range, use the ID as in the following example:
+To import the VMware Aria Automation Network IP range, use the ID as in the following example:
 
 `$ terraform import network_ip_range.new_ip_range 05956583-6488-4e7d-84c9-92a7b7219a15`

--- a/website/docs/r/vra_network_profile.html.markdown
+++ b/website/docs/r/vra_network_profile.html.markdown
@@ -1,12 +1,14 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_network_profile"
+page_title: "VMware Aria Automation: vra_network_profile"
 description: |-
   Provides a data lookup for vra_network_profile.
 ---
 
 # Resource: vra_network_profile
+
 ## Example Usages
+
 This is an example of how to create a network profile resource.
 
 **Network profile:**
@@ -40,13 +42,13 @@ A network profile resource supports the following arguments:
 * `description` - (Optional) A human-friendly description.
 
 * `fabric_network_ids` - (Optional) A list of fabric network Ids which are assigned to the network profile.
-                         example: `[ "6543" ]`
+                         Example: `[ "6543" ]`
 
 * `isolated_external_fabric_network_id` - (Optional) The id of the fabric network used for outbound access.
 
 * `name` - (Required) A human-friendly name used as an identifier in APIs that support this option.
 
-* `region_id` - (Required) The id of the region for which this profile is defined as in vRealize Automation(vRA).
+* `region_id` - (Required) The id of the region for which this profile is defined as in VMware Aria Automation.
 
 ## Attributes Reference
 
@@ -64,7 +66,7 @@ A network profile resource supports the following arguments:
 
 * `isolation_type` - Specifies the isolation type e.g. none, subnet or security group
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - ID of organization that entity belongs to.
 
@@ -73,9 +75,8 @@ A network profile resource supports the following arguments:
 * `owner` - Email of the user that owns the entity.
 
 * `security_group_ids` - A list of security group Ids which are assigned to the network profile.
-                         example: `[ "6545" ]`
+                         Example: `[ "6545" ]`
 
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/r/vra_project.html.markdown
+++ b/website/docs/r/vra_project.html.markdown
@@ -1,10 +1,11 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_project"
+page_title: "VMware Aria Automation: vra_project"
 description: |-
-  Provides a VMware vRealize Automation vra_project resource.
+  Provides a VMware Aria Automation vra_project resource.
 ---
-# Resource: vra\_project
+
+# Resource: vra_project
 
 ## Example Usages
 
@@ -150,7 +151,7 @@ A project resource supports the following arguments:
 
 * `zone_assignments` - (Optional) A list of configurations for zone assignment to a project.
 
-**Due to the design of the vRealize Automation IaaS API to update a project, it's not able to add and remove user or group at the same time. Please execute `terraform apply` twice.**
+> **Note**: Due to the design of the VMware Aria Automation IaaS API to update a project, it's not able to add and remove user or group at the same time. Please execute `terraform apply` twice.
 
 Initially, we have `jason` and `tony` configured as administrator. The initial the configuration:
 
@@ -181,4 +182,3 @@ Next, we want to add `bob` as a new administrator and remove `jason`. The modifi
 ```
 
 To complete the whole operation, it requires running `terraform apply` twice.
-

--- a/website/docs/r/vra_storage_profile.html.markdown
+++ b/website/docs/r/vra_storage_profile.html.markdown
@@ -1,15 +1,17 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile"
+page_title: "VMware Aria Automation: vra_storage_profile"
 description: |-
   Provides a data lookup for vra_storage_profile.
 ---
 
 # Resource: vra_storage_profile
+
 ## Example Usages
+
 This is an example of how to create a storage profile resource.
 
-**Vra storage profile:**
+**storage profile:**
 
 ```hcl
 # vSphere storage profile using generic vra_storage_profile resource.
@@ -87,7 +89,7 @@ A storage profile resource supports the following arguments:
 
 * `disk_target_properties` - (Optional) Map of storage placements to know where the disk is provisioned.
 
-* `region_id` - (Required) The id of the region for which this profile is defined as in vRealize Automation(vRA).
+* `region_id` - (Required) The id of the region for which this profile is defined as in VMware Aria Automation.
 
 * `supports_encryption` - (Optional) Indicates whether this storage profile supports encryption or not.
 
@@ -101,7 +103,7 @@ A storage profile resource supports the following arguments:
 
 * `default_item` - Indicates if this storage profile is a default profile.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `name` - A human-friendly name used as an identifier in APIs that support this option.
 
@@ -109,7 +111,6 @@ A storage profile resource supports the following arguments:
 
 * `owner` - Email of the user that owns the entity.
 
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/r/vra_storage_profile_aws.html.markdown
+++ b/website/docs/r/vra_storage_profile_aws.html.markdown
@@ -1,15 +1,17 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile_aws"
+page_title: "VMware Aria Automation: vra_storage_profile_aws"
 description: |-
   Provides a data lookup for vra_storage_profile_aws.
 ---
 
 # Resource: vra_storage_profile_aws
+
 ## Example Usages
+
 This is an example of how to create a storage profile aws resource.
 
-**Vra storage profile aws:**
+**storage profile aws:**
 
 ```hcl
 # AWS storage profile using vra_storage_profile_aws resource and EBS disk type.
@@ -46,7 +48,6 @@ resource "vra_storage_profile_aws" "this" {
     value = "bar"
   }
 }
-
 ```
 
 A storage profile aws resource supports the following arguments:
@@ -67,8 +68,7 @@ A storage profile aws resource supports the following arguments:
 
 * `supports_encryption` - (Optional) Indicates whether this storage profile supports encryption or not.
 
-* `tags` - (Optional) A set of tag keys and optional values that were set on this Network Profile.
-           example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - (Optional) A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `volume_type` - (Optional) Indicates the type of volume associated with type of storage.
 
@@ -78,7 +78,7 @@ A storage profile aws resource supports the following arguments:
 
 * `external_region_id` - The id of the region as seen in the cloud provider for which this profile is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `organization_id` - The id of the organization this entity belongs to.
 

--- a/website/docs/r/vra_storage_profile_azure.html.markdown
+++ b/website/docs/r/vra_storage_profile_azure.html.markdown
@@ -1,15 +1,17 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile_azure"
+page_title: "VMware Aria Automation: vra_storage_profile_azure"
 description: |-
   Provides a data lookup for vra_storage_profile_azure.
 ---
 
 # Resource: vra_storage_profile_azure
+
 ## Example Usages
+
 This is an example of how to create a storage profile azure resource.
 
-**Vra storage profile azure:**
+**storage profile azure:**
 
 ```hcl
 # Azure storage profile using vra_storage_profile_azure resource with managed disk.
@@ -76,13 +78,12 @@ A storage profile azure resource supports the following arguments:
 
 * `external_region_id` - The id of the region as seen in the cloud provider for which this profile is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `organization_id` - The id of the organization this entity belongs to.
 
 * `owner` - Email of the user that owns the entity.
 
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-                      example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/r/vra_storage_profile_vsphere.html.markdown
+++ b/website/docs/r/vra_storage_profile_vsphere.html.markdown
@@ -1,15 +1,17 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_storage_profile_vsphere"
+page_title: "VMware Aria Automation: vra_storage_profile_vsphere"
 description: |-
   Provides a data lookup for vra_storage_profile_vsphere.
 ---
 
 # Resource: vra_storage_profile_vsphere
+
 ## Example Usages
+
 This is an example of how to create a storage profile vsphere resource.
 
-**Vra storage profile vsphere:**
+**storage profile vsphere:**
 
 ```hcl
 # vSphere storage profile using generic vra_storage_profile resource.
@@ -72,14 +74,12 @@ A storage profile vsphere resource supports the following arguments:
 
 * `external_region_id` - The id of the region as seen in the cloud provider for which this profile is defined.
 
-* `links` - HATEOAS of the entity
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of the entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 
 * `owner` - Email of the user that owns the entity.
 
-
-* `tags` - A set of tag keys and optional values that were set on this Network Profile.
-                      example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
+* `tags` - A set of tag keys and optional values that were set on this Network Profile. Example: `[ { "key" : "ownedBy", "value": "Rainpole" } ]`
 
 * `updated_at` - Date when the entity was last updated. The date is ISO 8601 and UTC.

--- a/website/docs/r/vra_zone.html.markdown
+++ b/website/docs/r/vra_zone.html.markdown
@@ -1,8 +1,8 @@
 ---
 layout: "vra"
-page_title: "VMware vRealize Automation: vra_zone"
+page_title: "VMware Aria Automation: vra_zone"
 description: |-
-  Provides a VMware vRA vra_zone resource.
+  Provides a vra_zone resource.
 ---
 
 # Resource: vra_zone
@@ -48,13 +48,16 @@ A zone resource supports the following arguments:
 * `region_id` - (Required) The id of the region for which this zone is created.
 
 * `tags` - (Optional) A set of tag keys and optional values that were set on this resource:
+
   * `key` - Tag’s key.
+
   * `value` - Tag’s value.
 
 * `tags_to_match` - (Optional) A set of tag keys and optional values for compute resource filtering:
-  * `key` - Tag’s key.
-  * `value` - Tag’s value.
 
+  * `key` - Tag’s key.
+
+  * `value` - Tag’s value.
 
 ## Attribute Reference
 
@@ -64,7 +67,7 @@ A zone resource supports the following arguments:
 
 * `external_region_id` - The id of the region for which this zone is defined.
 
-* `links` - HATEOAS of entity.
+* `links` - Hypermedia as the Engine of Application State (HATEOAS) of entity.
 
 * `org_id` - The id of the organization this entity belongs to.
 


### PR DESCRIPTION
### Description

- Addresses common markdown formatting issues in `./website` content. A few of the edits address the Registry rendering:

     ![image](https://github.com/user-attachments/assets/7ae52c14-1dcc-49dd-a425-2ef2a77fe2a8)

- Also updates "vRealize Automation" to "Aria Automation" to match the project description. This should later be changed to `VMware Cloud Foundation Automation" and denote use for the classic experience but leaving as this for the time being.

I'll follow-up after to ensure the formatting if content headers are consistent.