### PR TITLE
chore(gh): update workflow permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,16 +1,17 @@
----
-name: Manage Stale Items
+name: Stale
 
 on:
   schedule:
     - cron: 00 00 * * *
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
-name: golang-test
+name: Test
 
 on:
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   gotest:


### PR DESCRIPTION
### Description

Explicitly defines the permissions granted to the `GITHUB_TOKEN` used within the workflows.

By default, the `GITHUB_TOKEN` has broad write access. Limiting these permissions to only what the workflow actually needs.

### Reference

https://github.com/vmware/terraform-provider-vra/security/code-scanning/2