### PR TITLE
chore: upgrade to golangci-lint v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,12 +1,13 @@
+---
 name: golangci-lint
 
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
+      - README.md
   push:
     paths-ignore:
-      - 'README.md'
+      - README.md
 
 permissions:
   contents: read
@@ -18,17 +19,17 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Go
-        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: go.mod
           cache: true
       - run: go mod download
       - run: go build -v .
       - name: Run Linters
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.60.3
+          version: latest
           args: --issues-exit-code=1
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,33 +1,11 @@
-# © Broadcom. All Rights Reserved.
-# The term “Broadcom” refers to Broadcom Inc. and/or its subsidiaries.
-# SPDX-License-Identifier: MPL-2.0
-
-# For more information about the golangci-lint configuration file, refer to:
-# https://golangci-lint.run/usage/configuration/
-
-issues:
-  max-per-linter: 0
-  max-same-issues: 0
-  exclude-rules:
-    # Exclude errcheck for some rules.
-  - linters: [errcheck]
-    text: "Error return value of `d.Set` is not checked"
-    # Exclude revive for some rules.
-  - linters:
-    - revive
-    text: 'redefines-builtin-id: redefinition of the built-in'
-
-run:
-  deadline: 5m
+---
+version: "2"
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - durationcheck
     - errcheck
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - makezero
@@ -35,15 +13,59 @@ linters:
     - nakedret
     - revive
     - staticcheck
-    - tenv
-    - typecheck
     - unconvert
     - unused
-    - govet
+  settings:
+    errcheck:
+      exclude-functions:
+        - github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set
+        - fmt:.*
+        - io:Close
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        text: Error return value of `d.Set` is not checked
+      - linters:
+          - revive
+        text: 'redefines-builtin-id: redefinition of the built-in'
+      # TODO: Setting temporary exclusions.
+      - linters:
+          - staticcheck
+        text: QF1001
+      - linters:
+          - staticcheck
+        text: QF1003
+      - linters:
+          - staticcheck
+        text: ST1005
+      - linters:
+          - staticcheck
+        text: QF1004
+      - linters:
+          - staticcheck
+        text: QF1011
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set"
-      - "fmt:.*"
-      - "io:Close"
+issues:
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
- Upgrades to `golangci-lint` configuration to support v2.
- Updates workflow to v7 that supports `golangci-lint` v2.