### PR TITLE
refactor: use nil slice declaration

### DIFF
--- a/vra/data_source_deployment.go
+++ b/vra/data_source_deployment.go
@@ -163,7 +163,7 @@ func dataSourceDeploymentRead(_ context.Context, d *schema.ResourceData, m inter
 	}
 
 	// Get the deployment details with all the user provided flags
-	expand := []string{}
+	var expand []string
 	expandProject := d.Get("expand_project").(bool)
 	if expandProject {
 		expand = append(expand, "project")

--- a/vra/regions.go
+++ b/vra/regions.go
@@ -9,7 +9,7 @@ import (
 )
 
 func extractIDsFromRegion(regions []*models.Region) []string {
-	regionIDs := []string{}
+	var regionIDs []string
 
 	for _, region := range regions {
 		regionIDs = append(regionIDs, *region.ExternalRegionID)
@@ -19,7 +19,7 @@ func extractIDsFromRegion(regions []*models.Region) []string {
 }
 
 func extractIDsFromRegionSpecification(regions []*models.RegionSpecification) []string {
-	regionIDs := []string{}
+	var regionIDs []string
 
 	for _, region := range regions {
 		regionIDs = append(regionIDs, *region.ExternalRegionID)

--- a/vra/resource_network_ip_range.go
+++ b/vra/resource_network_ip_range.go
@@ -110,7 +110,7 @@ func resourceNetworkIPRangeCreate(ctx context.Context, d *schema.ResourceData, m
 	name := d.Get("name").(string)
 	endIPAddress := d.Get("end_ip_address").(string)
 	startIPAddress := d.Get("start_ip_address").(string)
-	fabricNetworkIDs := []string{}
+	var fabricNetworkIDs []string
 	if v, ok := d.GetOk("fabric_network_ids"); ok {
 		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified fabric_network_ids are not unique"))
@@ -201,7 +201,7 @@ func resourceNetworkIPRangeUpdate(ctx context.Context, d *schema.ResourceData, m
 	name := d.Get("name").(string)
 	endIPAddress := d.Get("end_ip_address").(string)
 	startIPAddress := d.Get("start_ip_address").(string)
-	fabricNetworkIDs := []string{}
+	var fabricNetworkIDs []string
 	if v, ok := d.GetOk("fabric_network_ids"); ok {
 		if !compareUnique(v.(*schema.Set).List()) {
 			return diag.FromErr(errors.New("specified fabric_network_ids are not unique"))

--- a/vra/resource_policy_day2_action.go
+++ b/vra/resource_policy_day2_action.go
@@ -120,7 +120,7 @@ func resourcePolicyDay2Action() *schema.Resource {
 func resourcePolicyDay2ActionCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	apiClient := m.(*Client).apiClient
 
-	actions := []string{}
+	var actions []string
 	if actionsList, ok := d.GetOk("actions"); ok {
 		if !compareUnique(actionsList.(*schema.Set).List()) {
 			return diag.Errorf("`actions` must be unique")
@@ -223,7 +223,7 @@ func resourcePolicyDay2ActionUpdate(ctx context.Context, d *schema.ResourceData,
 
 	id := d.Id()
 
-	actions := []string{}
+	var actions []string
 	if actionsList, ok := d.GetOk("actions"); ok {
 		if !compareUnique(actionsList.(*schema.Set).List()) {
 			return diag.Errorf("`actions` must be unique")


### PR DESCRIPTION
Replaces empty slice declaration with nil slice declaration.

An empty slice can be represented by nil or an empty slice literal. They are functionally equivalent — their len and cap are both zero — but the nil slice is the preferred style.