### PR TITLE
fix: add input support for `blueprint_content`

### DIFF
--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -300,11 +300,15 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, m int
 		}
 
 		if v, ok := d.GetOk("inputs"); ok {
-			// If the inputs are provided, get the schema from blueprint to convert the provided input values
-			// to the type defined in the schema.
-			inputs, err = getBlueprintInputsByType(apiClient, blueprintID, blueprintVersion, v)
-			if err != nil {
-				return diag.FromErr(err)
+			if blueprintContent != "" && blueprintID == "" {
+				inputs = expandInputs(v)
+			} else {
+				// If the inputs are provided, get the schema from blueprint to convert the provided input values
+				// to the type defined in the schema.
+				inputs, err = getBlueprintInputsByType(apiClient, blueprintID, blueprintVersion, v)
+				if err != nil {
+					return diag.FromErr(err)
+				}
 			}
 		}
 		blueprintRequest.Inputs = inputs
@@ -465,7 +469,9 @@ func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, m int
 	log.Printf("Starting to update the vra_deployment resource with name %s", d.Get("name"))
 	apiClient := m.(*Client).apiClient
 
-	if d.HasChange("blueprint_id") || d.HasChange("blueprint_version") || d.HasChange("blueprint_content") {
+	_, blueprintContentExists := d.GetOk("blueprint_content")
+
+	if d.HasChange("blueprint_id") || d.HasChange("blueprint_version") || blueprintContentExists {
 		err := updateDeploymentWithNewBlueprint(ctx, d, m, apiClient)
 		if err.HasError() {
 			return err
@@ -732,6 +738,23 @@ func updateDeploymentWithNewBlueprint(ctx context.Context, d *schema.ResourceDat
 		blueprintContent = v.(string)
 	}
 
+	// Use GetRawConfig to distinguish between values in the user's configuration of the resource vs state.
+	// This allows for migration between using blueprint_id and blueprint_content when values are already present (user specified config takes precedence).
+	configValue := d.GetRawConfig()
+
+	configHasBlueprintID := !configValue.GetAttr("blueprint_id").IsNull()
+	configHasBlueprintContent := !configValue.GetAttr("blueprint_content").IsNull()
+
+	// Empty blueprintContent if the user has specified blueprintID and not blueprintContent.
+	if configHasBlueprintID && !configHasBlueprintContent {
+		blueprintContent = ""
+	}
+
+	// Empty blueprintID if the user has specified blueprintContent and not blueprintID.
+	if configHasBlueprintContent && !configHasBlueprintID {
+		blueprintID = ""
+	}
+
 	if blueprintID != "" && blueprintContent != "" {
 		if blueprintID == "inline-blueprint" {
 			blueprintID = ""
@@ -768,13 +791,17 @@ func updateDeploymentWithNewBlueprint(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if v, ok := d.GetOk("inputs"); ok {
-		// If the inputs are provided, get the schema from blueprint to convert the provided input values
-		// to the type defined in the schema.
-		inputs, err := getBlueprintInputsByType(apiClient, blueprintID, blueprintVersion, v)
-		if err != nil {
-			return diag.FromErr(err)
+		if blueprintContent != "" {
+			blueprintRequest.Inputs = expandInputs(v)
+		} else {
+			// If the inputs are provided, get the schema from blueprint to convert the provided input values
+			// to the type defined in the schema.
+			inputs, err := getBlueprintInputsByType(apiClient, blueprintID, blueprintVersion, v)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			blueprintRequest.Inputs = inputs
 		}
-		blueprintRequest.Inputs = inputs
 	} else {
 		blueprintRequest.Inputs = make(map[string]interface{})
 	}


### PR DESCRIPTION
### Problem
The previous logic for the `updateDeploymentWithNewBlueprint` function results in an error when:
- An existing deployment (with a `blueprint_id` and `blueprint_version` associated) is imported to the `vra_deployment` resource
- A subsequent apply is performed which uses `blueprint_content` instead of `blueprint_id` and `blueprint_version`
- An error message is produced that `blueprint_id` and `blueprint_content` cannot be used at the same time (even though `blueprint_id` is not specified in the resource config)

Additionally, when using blueprint content, the Update Day 2 action is called for certain operations on the deployment. This is an incorrect behaviour, as when using blueprint content, the Update Day 2 action is not available. Performing the update through the Blueprint API should be the preferred path.

### Solution

This commit resolves the issue by giving precedence to what is specified by the user as part of the resource configuration. It also utilises the Blueprint Update API for updating existing deployments with `blueprint_content`.

Support is also added for using inputs in combination with `blueprint_content`.

### Testing

Tested with imported deployments and net-new deployments created by the provider

✅ Deployments can now interchange between using `blueprint_content` and `blueprint_id` (as is supported by the API)
✅ No impacts to existing net-new deployment lifecycle (using blueprint ID)
✅ Inputs can now be used in tandem with `blueprint_content`
✅ Deployment creation, update and deletion tested for both net-new deployments and imported deployments.

### Impact
Changes behaviour for users using blueprint_content as part of their deployment resource.



