### PR TITLE
fix: Add Computed: true to deployment inputs field

### DIFF
--- a/vra/resource_deployment.go
+++ b/vra/resource_deployment.go
@@ -116,6 +116,7 @@ func resourceDeployment() *schema.Resource {
 			"inputs": {
 				Type:        schema.TypeMap,
 				Optional:    true,
+				Computed:    true,
 				Description: "Inputs provided by the user. For inputs including those with default values, refer to inputs_including_defaults.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
Allow deployment inputs to reference values that are only known at apply time (e.g. IP addresses allocated by an IPAM solution or other resources with computed outputs).

Without Computed: true, Terraform raises an 'inconsistent result after apply' error when an input value changes between plan and apply. Setting Computed: true on the TypeMap field signals to the SDK that provider-resolved values are acceptable, enabling unknown-at-plan-time references to flow through correctly.

Known literal input values continue to display in the plan output unchanged.